### PR TITLE
Add clang format script to local and CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,123 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: false
+SpaceBeforeInheritanceColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,18 +1,28 @@
 name: lint
 
-on:
-  pull_request:
-    paths:
-    - '**/BUILD*'
-    - 'WORKSPACE'
-    - '**/*.bzl'
+on: [pull_request]
 
 jobs:
-  buildifier:
+  check_format:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install buildifier
+      run: go get github.com/bazelbuild/buildtools/buildifier
+
     - name: Run buildifier
-      run: bazelisk run //:buildifier_check
+      run: buildifier --mode=check -r .
+
+    # Speed things up a bit
+    - name: Disable initramfs update
+      run: sudo sed -i 's/yes/no/g' /etc/initramfs-tools/update-initramfs.conf
+    - name: Disable man-db update
+      run: sudo rm -f /var/lib/man-db/auto-update
+
+    - name: Install clang-format
+      run: sudo apt install clang-format
+
+    - name: Run clang-format
+      run: ./scripts/clang-format.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,12 @@ jobs:
 
     - name: Install buildifier
       run: | 
-        curl -f -L -o /usr/bin/buildifier \
+        curl -f -L -o ./buildifier \
           "https://github.com/bazelbuild/buildtools/releases/download/4.0.1/buildifier" \
-        && chmod +x /usr/bin/buildifier
+        && chmod +x ./buildifier
 
     - name: Run buildifier
-      run: buildifier --mode=check -r .
+      run: ./buildifier --mode=check -r .
 
     # Speed things up a bit
     - name: Disable initramfs update

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
 
     - name: Install buildifier
-      run: go get github.com/bazelbuild/buildtools/buildifier
+      run: | 
+        curl -f -L -o /usr/bin/buildifier \
+          "https://github.com/bazelbuild/buildtools/releases/download/4.0.1/buildifier" \
+        && chmod +x /usr/bin/buildifier
 
     - name: Run buildifier
       run: buildifier --mode=check -r .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
 
     - name: Install buildifier
       run: go get github.com/bazelbuild/buildtools/buildifier

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: lint
 
-on: [pull_request]
+on: [push,pull_request]
 
 jobs:
   check_format:

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -15,8 +15,8 @@ then
         exit 0
     fi
 else
-    out=$(git-clang-format -f --diff --style file -q ./**/*)
-    if [ "$out" != "" ]
+    out=$(git-clang-format -f --diff --style file ./**/* -q)
+    if [ "$out" != "no modified files to format" ]
     then
         echo "Formatting errors"
         exit 1

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if ! command -v git-clang-format &> /dev/null
+then
+    echo "git-clang-format could not be found. Install with sudo apt install clang-format"
+    exit
+fi
+
+if [ "$1" = "run" ]
+then
+    out=$(git-clang-format -f --style file ./**/*)
+    if [ "$out" != "" ]
+    then
+        echo $out
+        exit 0
+    fi
+else
+    out=$(git-clang-format -f --diff --style file -q ./**/*)
+    if [ "$out" != "" ]
+    then
+        echo "Formatting errors"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
Users will have to install clang-format manually with `sudo apt install clang-format`. The script can be invoked to auto format the files using:

```bash
./scripts/clang_format.sh run
```

Also adds a clang_format check to GitHub Actions CI.