### PR TITLE
Fix clang format script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,7 +17,7 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
-AllowShortLoopsOnASingleLine: true
+AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
+# Ensure git-clang-format is installed
 if ! command -v git-clang-format &> /dev/null
 then
     echo "git-clang-format could not be found. Install with sudo apt install clang-format"
-    exit
+    exit 1
 fi
+
+exec 2>&1
 
 if [ "$1" = "run" ]
 then
-    out=$(git-clang-format -f --style file ./**/*)
-    if [ "$out" != "" ]
-    then
-        echo $out
-        exit 0
-    fi
+    git-clang-format -f --style=file --commit origin/main
 else
-    out=$(git-clang-format -f --diff --style file ./**/* -q)
+    out=$(git-clang-format -f --diff --commit origin/main --style=file -q)
     if [ "$out" != "no modified files to format" ]
     then
         echo "Formatting errors"
         exit 1
     fi
 fi
+
+exit 0


### PR DESCRIPTION
There was an issue before where the script to check in CI wouldn't detect errors because it was just checking for unstaged files in git, but because it's in a PR, all the changes are committed. Now the script checks code formatting against origin/main, since that's where all PRs should be merged into.