### PR TITLE
Modify GPIO interrupt implementation

### DIFF
--- a/libs/gpio/api.h
+++ b/libs/gpio/api.h
@@ -10,6 +10,9 @@ typedef struct {
     uint8_t pin;
 } gpio_t;
 
+/*
+ * Set a GPIO pin to be an input or an output
+ */
 #define gpio_set_mode(gpio_pin, mode)                       \
     do {                                                    \
         if (mode == OUTPUT) {                               \
@@ -19,11 +22,35 @@ typedef struct {
         }                                                   \
     } while (0)
 
+/*
+ * Set a gpio pin high
+ */
 #define gpio_set_pin(gpio_pin) (_SFR_IO8(gpio_pin.port) |= (1 << gpio_pin.num))
+
+/*
+ * Set a gpio pin low
+ */
 #define gpio_clear_pin(gpio_pin) \
     (_SFR_IO8(gpio_pin.port) &= ~(1 << gpio_pin.num))
+
+/*
+ * Toggle a gpio pin (high becomes low, low becomes high)
+ */
 #define gpio_toggle_pin(gpio_pin) \
     (_SFR_IO8(gpio_pin.port) ^= (1 << gpio_pin.num))
+
+/*
+ * Get the value of a GPIO pin
+ */
 #define gpio_get_pin(gpio_pin) (_SFR_IO8(gpio_pin.pin) & (1 << gpio_pin.num))
 
+/*
+ * Enable interrupts for the given pin. The interrupt function can then be
+ * defined like so:
+ *
+ * ```
+ * void pcint0_callback(void) {
+ *     // Do interrupt stuff
+ * }
+ */
 void gpio_enable_interrupt(gpio_t pin);

--- a/libs/gpio/api.h
+++ b/libs/gpio/api.h
@@ -26,4 +26,4 @@ typedef struct {
     (_SFR_IO8(gpio_pin.port) ^= (1 << gpio_pin.num))
 #define gpio_get_pin(gpio_pin) (_SFR_IO8(gpio_pin.pin) & (1 << gpio_pin.num))
 
-void gpio_attach_interrupt(gpio_t pin, void (*callback)(void));
+void gpio_enable_interrupt(gpio_t pin);

--- a/libs/gpio/gpio.c
+++ b/libs/gpio/gpio.c
@@ -4,13 +4,26 @@
 
 #include "libs/gpio/api.h"
 
-#define NUM_PIN_INTERRUPTS (26)
-
 /*
- * List of function pointers to store the callbacks
+ * Placeholder functions for interrupt callbacks for the pin change interrupt
+ * vectors.
+ *
+ * The string `__attribute__((weak))` tells the compiler that there are default
+ * functions that are defined here, but if someone implements them elsewhere,
+ * use the other ones.
+ *
+ * So we have these defined as weak so that the code will always compile, and
+ * then in your code file (like `air_control.c`), you can define a function with
+ * the same name:
+ *
+ * ```
+ * void pcint0_callback(void) {
+ *     // Decide which pin changed, and do something
+ * }
+ * ```
+ *
+ * This is how interrupts work in this library.
  */
-// void (*callbacks[NUM_PIN_INTERRUPTS])(void);
-
 __attribute__((weak)) void pcint0_callback(void) {};
 __attribute__((weak)) void pcint1_callback(void) {};
 __attribute__((weak)) void pcint2_callback(void) {};
@@ -38,25 +51,18 @@ void gpio_enable_interrupt(gpio_t pin) {
         case 0x05: {
             PCICR |= (1 << PCIE0);
             PCMSK0 |= (1 << pin.num);
-            // callbacks[pin.num] = callback;
         } break;
         case 0x08: {
             PCICR |= (1 << PCIE1);
             PCMSK1 |= (1 << pin.num);
-            // callbacks[pin.num + 8] = callback;
         } break;
         case 0x0B: {
             PCICR |= (1 << PCIE2);
             PCMSK2 |= (1 << pin.num);
-            // callbacks[pin.num + 16] = callback;
         } break;
         case 0x0E: {
             PCICR |= (1 << PCIE3);
             PCMSK3 |= (1 << pin.num);
-            // callbacks[pin.num + 24] = callback;
-        } break;
-        default: {
-            // Nothing
         } break;
     }
 }

--- a/libs/gpio/gpio.c
+++ b/libs/gpio/gpio.c
@@ -9,90 +9,51 @@
 /*
  * List of function pointers to store the callbacks
  */
-void (*callbacks[NUM_PIN_INTERRUPTS])(void);
+// void (*callbacks[NUM_PIN_INTERRUPTS])(void);
+
+__attribute__((weak)) void pcint0_callback(void) {};
+__attribute__((weak)) void pcint1_callback(void) {};
+__attribute__((weak)) void pcint2_callback(void) {};
+__attribute__((weak)) void pcint3_callback(void) {};
 
 ISR(PCINT0_vect) {
-    static uint8_t prev_vals = 0;
-    uint8_t vals = PINB;
-
-    uint8_t changed = prev_vals ^ vals;
-
-    for (uint8_t i = 0; i < 8; i++) {
-        if ((changed & (1 << i)) && (callbacks[i] != NULL)) {
-            (*callbacks[i])();
-        }
-    }
-
-    prev_vals = vals;
+    pcint0_callback();
 }
 
 ISR(PCINT1_vect) {
-    static uint8_t prev_vals = 0;
-    uint8_t vals = PINC;
-
-    uint8_t changed = prev_vals ^ vals;
-
-    for (uint8_t i = 0; i < 8; i++) {
-        if ((changed & (1 << i)) && (callbacks[i + 8] != NULL)) {
-            (*callbacks[i + 8])();
-        }
-    }
-
-    prev_vals = vals;
+    pcint1_callback();
 }
 
 ISR(PCINT2_vect) {
-    static uint8_t prev_vals = 0;
-    uint8_t vals = PIND;
-
-    uint8_t changed = prev_vals ^ vals;
-
-    for (uint8_t i = 0; i < 8; i++) {
-        if ((changed & (1 << i)) && (callbacks[i + 16] != NULL)) {
-            (*callbacks[i + 16])();
-        }
-    }
-
-    prev_vals = vals;
+    pcint2_callback();
 }
 
 ISR(PCINT3_vect) {
-    static uint8_t prev_vals = 0;
-    uint8_t vals = PINE;
-
-    uint8_t changed = prev_vals ^ vals;
-
-    for (uint8_t i = 0; i < 3; i++) {
-        if ((changed & (1 << i)) && (callbacks[i + 24] != NULL)) {
-            (*callbacks[i + 24])();
-        }
-    }
-
-    prev_vals = vals;
+    pcint3_callback();
 }
 
-void gpio_attach_interrupt(gpio_t pin, void (*callback)(void)) {
+void gpio_enable_interrupt(gpio_t pin) {
     sei();
     switch (pin.port) {
         case 0x05: {
             PCICR |= (1 << PCIE0);
             PCMSK0 |= (1 << pin.num);
-            callbacks[pin.num] = callback;
+            // callbacks[pin.num] = callback;
         } break;
         case 0x08: {
             PCICR |= (1 << PCIE1);
             PCMSK1 |= (1 << pin.num);
-            callbacks[pin.num + 8] = callback;
+            // callbacks[pin.num + 8] = callback;
         } break;
         case 0x0B: {
             PCICR |= (1 << PCIE2);
             PCMSK2 |= (1 << pin.num);
-            callbacks[pin.num + 16] = callback;
+            // callbacks[pin.num + 16] = callback;
         } break;
         case 0x0E: {
             PCICR |= (1 << PCIE3);
             PCMSK3 |= (1 << pin.num);
-            callbacks[pin.num + 24] = callback;
+            // callbacks[pin.num + 24] = callback;
         } break;
         default: {
             // Nothing


### PR DESCRIPTION
Previously, we had a system where you could register a callback function for _each_ pin on a pin change interrupt vector (like `PCINT0_vect`) so that you could target individual pins, but this added a lot of overhead and slowed down the interrupts substantially and caused errors.

The new implementation changes it so that we have a single callback function for each ISR and we can enable interrupts for a single pin, but the same function gets called. So there's one interrupt per 8 pins, and four interrupts total (PORTB, PORTC, PORTD, and PORTE).

The callback functions are initially declared as `__attribute__((weak))` which means they are "weakly defined", meaning the code will compile but the intention is that if you want to, you can redefine the functions in your code and instead of resolving to the weakly defined function it'll resolve to the one you wrote.