### PR TITLE
Add fixes and updates to CAN API

### DIFF
--- a/libs/can/BUILD
+++ b/libs/can/BUILD
@@ -1,6 +1,4 @@
-load("//bazel:defs.bzl", "cc_firmware")
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//bazel/tools:defs.bzl", "can_api_files")
 
 cc_library(
     name = "hdrs",
@@ -24,15 +22,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":hdrs",
-    ],
-)
-
-cc_test(
-    name = "utest",
-    srcs = ["test/utest.c"],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":mock",
     ],
 )
 
@@ -67,23 +56,4 @@ cc_library(
         "//bazel/constraints:atmega16m1",
     ],
     visibility = ["//visibility:public"],
-)
-
-can_api_files(
-    name = "air_control_can_api",
-    dbc = "//vehicle/mkv:mkv.dbc",
-    yaml = "//vehicle/mkv/software/air_control:air.yml",
-)
-
-cc_firmware(
-    name = "app_test",
-    srcs = ["test/test_app.c"],
-    target_compatible_with = [
-        "//bazel/constraints:atmega16m1",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":air_control_can_api",
-        "//libs/can",
-    ],
 )

--- a/libs/can/api.h
+++ b/libs/can/api.h
@@ -44,6 +44,11 @@ void can_init(baud_rate_t baud);
 void can_enable_interrupt(uint8_t mob);
 
 /*
+ * Returns 0 if there is no interrupt for the given MOb, and (1 << mob) if so
+ */
+int can_mob_has_interrupt(uint8_t mob);
+
+/*
  * Sends a CAN message
  *
  * @param[in] frame - CAN frame struct

--- a/libs/can/mob.h
+++ b/libs/can/mob.h
@@ -1,12 +1,12 @@
 #include <avr/io.h>
 
 typedef enum {
-    CAN_MOB0,
-    CAN_MOB1,
-    CAN_MOB2,
-    CAN_MOB3,
-    CAN_MOB4,
-    CAN_MOB5,
+    CAN_MOB0 = 0,
+    CAN_MOB1 = 1,
+    CAN_MOB2 = 2,
+    CAN_MOB3 = 3,
+    CAN_MOB4 = 4,
+    CAN_MOB5 = 5,
 
     // Must be last!
     CAN_NUM_MOB,

--- a/libs/can/test/BUILD
+++ b/libs/can/test/BUILD
@@ -1,0 +1,36 @@
+load("//bazel:defs.bzl", "cc_firmware")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel/tools:defs.bzl", "can_api_files")
+
+exports_files([
+    "test.yml",
+])
+
+can_api_files(
+    name = "test_can_api",
+    dbc = "//vehicle/mkv:mkv.dbc",
+    yaml = ":test.yml",
+)
+
+cc_firmware(
+    name = "test_app",
+    srcs = ["test_app.c"],
+    target_compatible_with = [
+        "//bazel/constraints:atmega16m1",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test_can_api",
+        "//libs/can",
+        "//libs/timer",
+    ],
+)
+
+cc_test(
+    name = "utest",
+    srcs = ["utest.c"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/can:mock",
+    ],
+)

--- a/libs/can/test/test.yml
+++ b/libs/can/test/test.yml
@@ -1,6 +1,6 @@
 name: test_node
 subscribe:
-  - name: bms_core
+  - name: air_control_critical
     mob: 1
 publish:
   - name: test_msg

--- a/libs/can/test/test.yml
+++ b/libs/can/test/test.yml
@@ -1,0 +1,16 @@
+name: test_node
+subscribe:
+  - name: bms_core
+    mob: 1
+publish:
+  - name: test_msg
+    id: 0x700
+    freq_hz: 10
+    signals:
+      - name: test_sig
+        slice: 0 + 8
+        unit:
+          name: "V"
+          type: uint8_t
+          offset: 0
+          scale: 1

--- a/libs/can/test/test_app.c
+++ b/libs/can/test/test_app.c
@@ -8,24 +8,6 @@
 
 #define LED0 (PD6)
 
-uint8_t _bms_core_data[8] = { 0 };
-
-can_frame_t _bms_core_msg = {
-    .mob = 1,
-    .data = _bms_core_data,
-};
-
-can_filter_t _bms_core_filter = {
-    .id = 16,
-
-    /*
-     * TODO: It would be nice if this was configurable...
-     */
-    .mask = 0x7FF, // Exact match
-};
-
-struct can_tools_bms_core_t _bms_core = { 0 };
-
 void timer0_callback(void);
 
 timer_cfg_s timer0_cfg = {
@@ -56,17 +38,15 @@ int main(void) {
 
     int rc = 0;
 
-    can_receive_bms_core();
+    can_receive_air_control_critical();
 
     while (1) {
-        // rc = can_poll_receive(&_bms_core_msg);
-        rc = can_poll_receive_bms_core();
+        rc = can_poll_receive_air_control_critical();
 
         if (rc == 0) {
             test_msg.test_sig = test_msg.test_sig + 1;
             PORTD |= _BV(LED0);
-            can_receive_bms_core();
-            // can_receive(&_bms_core_msg, _bms_core_filter);
+            can_receive_air_control_critical();
         }
 
         if (send_can) {

--- a/projects/can_api/files/c_templates/c_file.j2
+++ b/projects/can_api/files/c_templates/c_file.j2
@@ -9,7 +9,7 @@ void can_init_{{ node.name }}(void) {
  * Transmit messages
  */
 {% for message in tx_messages %}
-uint8_t {{ message.name|lower }}_data[{{ message.length }}];
+uint8_t {{ message.name|lower }}_data[{{ message.length }}] = {0};
 
 can_frame_t {{ message.name|lower }}_msg = {
     .id = {{ message.frame_id }},
@@ -18,7 +18,7 @@ can_frame_t {{ message.name|lower }}_msg = {
     .dlc = {{ message.length }},
 };
 
-volatile struct can_tools_{{ message.name|lower }}_t {{ message.name|lower }};
+volatile struct can_tools_{{ message.name|lower }}_t {{ message.name|lower }} = {0};
 
 void can_send_{{ message.name|lower }}(void) {
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
@@ -42,7 +42,7 @@ void can_send_{{ message.name|lower }}(void) {
  * Receive messages
  */
 {% for message in rx_messages %}
-uint8_t {{ message.name|lower }}_data[{{ message.length }}];
+uint8_t {{ message.name|lower }}_data[{{ message.length }}] = {0};
 
 can_frame_t {{ message.name|lower }}_msg = {
     .mob = {{ mobs[message.name] }},
@@ -58,10 +58,16 @@ can_filter_t {{ message.name|lower }}_filter = {
     .mask = 0x7FF, // Exact match
 };
 
-struct can_tools_{{ message.name|lower }}_t {{ message.name|lower }};
+struct can_tools_{{ message.name|lower }}_t {{ message.name|lower }} = {0};
 
 int can_receive_{{ message.name|lower }}(void) {
-    int rc = can_receive(&{{ message.name|lower }}_msg, {{ message.name|lower }}_filter);
+    (void)can_receive(&{{ message.name|lower }}_msg, {{ message.name|lower }}_filter);
+
+    return 0;
+}
+
+int can_poll_receive_{{ message.name|lower }}(void) {
+    int rc = can_poll_receive(&{{ message.name|lower }}_msg);
 
     if (rc == 0) {
         can_tools_{{ message.name|lower }}_unpack(&{{ message.name|lower }}, {{ message.name|lower }}_msg.data, {{ message.length }});

--- a/projects/can_api/files/c_templates/h_file.j2
+++ b/projects/can_api/files/c_templates/h_file.j2
@@ -30,5 +30,6 @@ extern can_frame_t {{ message.name|lower }}_msg;
 extern struct can_tools_{{ message.name|lower }}_t {{ message.name|lower }};
 
 int can_receive_{{ message.name|lower }}(void);
+int can_poll_receive_{{ message.name|lower }}(void);
 
 {% endfor %}

--- a/vehicle/mkv/BUILD
+++ b/vehicle/mkv/BUILD
@@ -4,6 +4,7 @@ load("//bazel/tools:defs.bzl", "dbc_gen")
 dbc_gen(
     name = "mkv.dbc",
     srcs = [
+        "//libs/can/test:test.yml",
         "//vehicle/mkv/software/air_control:air.yml",
         "//vehicle/mkv/software/brakelight_bspd:bspd.yml",
         "//vehicle/mkv/software/motor_controller:motor_controller.dbc",


### PR DESCRIPTION
This splits up the original `can_receive_xxx()` functions in the CAN API into two separate `can_receive_xxx()` and `can_poll_receive_xxx()` functions, which is more inline with the original CAN library.

Also adds in support for CAN interrupts, for completeness's sake.