### PR TITLE
Add support for ATMega64m1

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,10 @@ build:64m1 --config=64m1-avr
 # Test target
 build:avr-test-sim --platforms=//bazel/platforms:avr_test_sim
 
+build:hitl-firmware-test --platforms=//bazel/platforms:hitl_firmware_test
+
+build:hackerboard --platforms=//bazel/platforms:hackerboard
+
 # Host target
 build:linux-x86_64 --platforms=//bazel/platforms:linux-x86_64
 
@@ -26,3 +30,6 @@ build:docker-kicad --experimental_docker_verbose
 build:docker-kicad --experimental_enable_docker_sandbox
 build:docker-kicad --incompatible_strict_action_env=true
 build:docker-kicad --experimental_docker_image=setsoft/kicad_auto
+
+# Because I can never remember the order...
+build:kicad-docker --config=docker-kicad

--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,9 @@ build:16m1 --config=m16m1-avr
 build:m328p-avr --platforms=//bazel/platforms:atmega328p_avr
 build:328p --config=m328p-avr
 
+build:64m1-avr --platforms=//bazel/platforms:atmega64m1_avr
+build:64m1 --config=64m1-avr
+
 # Test target
 build:avr-test-sim --platforms=//bazel/platforms:avr_test_sim
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [linux-x86_64 16m1 328p 64m1]
+        platform: [linux-x86_64, 16m1, 328p, 64m1]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux-x86_64 16m1 328p 64m1]
 
     steps:
     - uses: actions/checkout@v2
@@ -29,11 +32,7 @@ jobs:
       run: sudo apt install gcc-avr avr-libc binutils-avr
 
     - name: Build all host
-      run: bazelisk build -c opt --build_tag_filters="-kicad" //...
-    - name: Build all ATMega16m1
-      run: bazelisk build --config=m16m1-avr --build_tag_filters="-kicad" -c opt //...
-    - name: Build all ATMega328p
-      run: bazelisk build --config=m328p-avr --build_tag_filters="-kicad" -c opt //...
+      run: bazelisk build --config=${{ matrix.platform }} -c opt --build_tag_filters="-kicad" //...
 
   test:
     needs: build

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -113,8 +113,8 @@ pip_install(
 
 http_archive(
     name = "hedron_compile_commands",
-    strip_prefix = "bazel-compile-commands-extractor-140666077ab4ca7f10041080e8b55cf641c07d30",
     sha256 = "ce5714be202e942ba5f404d1c373a2fbb4b88c66737a924491fbd49afa91d48b",
+    strip_prefix = "bazel-compile-commands-extractor-140666077ab4ca7f10041080e8b55cf641c07d30",
     url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/140666077ab4ca7f10041080e8b55cf641c07d30.tar.gz",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,11 +114,8 @@ pip_install(
 http_archive(
     name = "hedron_compile_commands",
     strip_prefix = "bazel-compile-commands-extractor-140666077ab4ca7f10041080e8b55cf641c07d30",
-
-    # Replace the commit hash in both places (below) with the latest, rather than using the stale one here.
-    # Even better, set up Renovate and let it do the work for you (see "Suggestion: Updates" in the README).
+    sha256 = "ce5714be202e942ba5f404d1c373a2fbb4b88c66737a924491fbd49afa91d48b",
     url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/140666077ab4ca7f10041080e8b55cf641c07d30.tar.gz",
-    # When you first run this tool, it'll recommend a sha256 hash to put here with a message like: "DEBUG: Rule 'hedron_compile_commands' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = ..."
 )
 
 load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,8 @@ register_execution_platforms("@local_config_platform//:host", "//bazel/platforms
 
 register_toolchains("//bazel/toolchain:atmega16m1_toolchain")
 
+register_toolchains("//bazel/toolchain:atmega64m1_toolchain")
+
 register_toolchains("//bazel/toolchain:atmega328p_toolchain")
 
 http_archive(

--- a/bazel/constraints/BUILD
+++ b/bazel/constraints/BUILD
@@ -15,7 +15,17 @@ constraint_value(
 )
 
 constraint_value(
+    name = "atmega64m1",
+    constraint_setting = ":mcu",
+)
+
+constraint_value(
     name = "atmega328p",
+    constraint_setting = ":mcu",
+)
+
+constraint_value(
+    name = "incompatible_mcu",
     constraint_setting = ":mcu",
 )
 

--- a/bazel/constraints/BUILD
+++ b/bazel/constraints/BUILD
@@ -48,6 +48,11 @@ constraint_value(
 )
 
 constraint_value(
+    name = "hackerboard",
+    constraint_setting = ":environment",
+)
+
+constraint_value(
     name = "mkvi",
     constraint_setting = ":environment",
 )

--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -242,7 +242,7 @@ def cc_firmware(name, **kwargs):
         copts = select({
             "//bazel/constraints:hitl": ["-DBOARD_FIRMWARE_TEST"],
             "//bazel/constraints:hackerboard": ["-DBOARD_HACKERBOARD"],
-            "//conditions:default": []
+            "//conditions:default": [],
         }),
         **kwargs
     )

--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -231,11 +231,13 @@ def cc_firmware(name, **kwargs):
         name = "{}.elf".format(name),
         linkopts = select({
             "//bazel/constraints:atmega16m1": ["-T $(location //scripts/ldscripts:atmega16m1.ld)"],
+            "//bazel/constraints:atmega64m1": ["-T $(location //scripts/ldscripts:atmega64m1.ld)"],
             # Add more ldscripts here
             "//conditions:default": [],
         }),
         additional_linker_inputs = [
             "//scripts/ldscripts:atmega16m1.ld",
+            "//scripts/ldscripts:atmega64m1.ld",
         ],
         **kwargs
     )
@@ -282,6 +284,7 @@ def cc_firmware(name, **kwargs):
         part = select({
             "//bazel/constraints:atmega16m1": "16m1",
             "//bazel/constraints:atmega328p": "m328p",
+            "//bazel/constraints:atmega64m1": "64m1",
             "//conditions:default": "",
         }),
     )

--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -239,6 +239,11 @@ def cc_firmware(name, **kwargs):
             "//scripts/ldscripts:atmega16m1.ld",
             "//scripts/ldscripts:atmega64m1.ld",
         ],
+        copts = select({
+            "//bazel/constraints:hitl": ["-DBOARD_FIRMWARE_TEST"],
+            "//bazel/constraints:hackerboard": ["-DBOARD_HACKERBOARD"],
+            "//conditions:default": []
+        }),
         **kwargs
     )
 

--- a/bazel/platforms/BUILD
+++ b/bazel/platforms/BUILD
@@ -42,6 +42,28 @@ platform(
 )
 
 platform(
+    name = "hitl_firmware_test",
+    constraint_values = [
+        "//bazel/constraints:atmega64m1",
+        "//bazel/constraints:hitl",
+    ],
+    parents = [
+        ":avr_common",
+    ],
+)
+
+platform(
+    name = "hackerboard",
+    constraint_values = [
+        "//bazel/constraints:atmega16m1",
+        "//bazel/constraints:hackerboard",
+    ],
+    parents = [
+        ":avr_common",
+    ],
+)
+
+platform(
     name = "linux-x86_64",
     constraint_values = [
         "@platforms//os:linux",

--- a/bazel/platforms/BUILD
+++ b/bazel/platforms/BUILD
@@ -17,6 +17,14 @@ platform(
 )
 
 platform(
+    name = "atmega64m1_avr",
+    constraint_values = [
+        "//bazel/constraints:atmega64m1",
+    ],
+    parents = [":avr_common"],
+)
+
+platform(
     name = "atmega328p_avr",
     constraint_values = [
         "//bazel/constraints:atmega328p",

--- a/bazel/toolchain/BUILD
+++ b/bazel/toolchain/BUILD
@@ -6,4 +6,6 @@ package(
 
 create_avr_toolchain("atmega16m1", "4000000")
 
+create_avr_toolchain("atmega64m1", "4000000")
+
 create_avr_toolchain("atmega328p", "16000000")

--- a/bazel/toolchain/features.bzl
+++ b/bazel/toolchain/features.bzl
@@ -49,7 +49,7 @@ _DEBUG_FEATURE = feature(
         flag_set(
             actions = _C_ALL_COMPILE_ACTIONS,
             flag_groups = [
-                flag_group(flags = ["-O0", "-g3"]),
+                flag_group(flags = ["-Os", "-g3"]),
             ],
         ),
     ],

--- a/bazel/tools/avrdude.sh.tmpl
+++ b/bazel/tools/avrdude.sh.tmpl
@@ -8,7 +8,7 @@ fi
 
 _LFUSE=${LFUSE:=0x65}
 _HFUSE=${HFUSE:=0xD8}
-_EFUSE=${EFUSE:=0xFE}
+_EFUSE=${EFUSE:=0xFF}
 
 if [ ! -z ${DEBUG+x} ]; then
     printf "FUSE_OP: ${FUSE_OP}\\n"
@@ -17,7 +17,7 @@ if [ ! -z ${DEBUG+x} ]; then
     printf "  EFUSE: ${_EFUSE}\\n"
 fi
 
-avrdude -v -P usb -p {part} -F \
+avrdude -v -P usb -p {part} \
         -C {config} \
         -U lfuse:${FUSE_OP}:${_LFUSE}:m \
         -U hfuse:${FUSE_OP}:${_HFUSE}:m \

--- a/libs/adc/BUILD
+++ b/libs/adc/BUILD
@@ -13,9 +13,11 @@ cc_library(
     srcs = [
         "adc.c",
     ],
-    target_compatible_with = [
-        "//bazel/constraints:atmega16m1",
-    ],
+    target_compatible_with = select({
+        "//bazel/constraints:atmega16m1": [],
+        "//bazel/constraints:atmega64m1": [],
+        "//conditions:default": ["//bazel/constraints:incompatible_mcu"],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":hdrs",

--- a/libs/can/BUILD
+++ b/libs/can/BUILD
@@ -16,9 +16,11 @@ cc_library(
     hdrs = [
         "mob.h",
     ],
-    target_compatible_with = [
-        "//bazel/constraints:atmega16m1",
-    ],
+    target_compatible_with = select({
+        "//bazel/constraints:atmega16m1": [],
+        "//bazel/constraints:atmega64m1": [],
+        "//conditions:default": ["//bazel/constraints:incompatible_mcu"],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":hdrs",

--- a/libs/can/test/BUILD
+++ b/libs/can/test/BUILD
@@ -15,9 +15,11 @@ can_api_files(
 cc_firmware(
     name = "test_app",
     srcs = ["test_app.c"],
-    target_compatible_with = [
-        "//bazel/constraints:atmega16m1",
-    ],
+    target_compatible_with = select({
+        "//bazel/constraints:atmega16m1": [],
+        "//bazel/constraints:atmega64m1": [],
+        "//conditions:default": ["//bazel/constraints:incompatible_mcu"],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":test_can_api",

--- a/libs/gpio/BUILD
+++ b/libs/gpio/BUILD
@@ -13,7 +13,11 @@ cc_library(
     hdrs = [
         "pin_defs.h",
     ],
-    target_compatible_with = ["//bazel/constraints:atmega16m1"],
+    target_compatible_with = select({
+        "//bazel/constraints:atmega16m1": [],
+        "//bazel/constraints:atmega64m1": [],
+        "//conditions:default": ["//bazel/constraints:incompatible_mcu"],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":hdrs",

--- a/libs/spi/BUILD
+++ b/libs/spi/BUILD
@@ -29,13 +29,12 @@ cc_library(
     srcs = [
         "spi.c",
     ],
-    #https://docs.bazel.build/versions/main/platforms.html#more-expressive-constraints
-    # target_compatible_with = select({
-    #     "//bazel/constraints:atmega16m1": [],
-    #     # "//bazel/constraints:atmega328p": [],
-    #     # "//conditions:default": ["@platforms//:incompatible"],
-    # }),
-    target_compatible_with = ["//bazel/constraints:atmega16m1"],
+    target_compatible_with = select({
+        "//bazel/constraints:atmega16m1": [],
+        "//bazel/constraints:atmega64m1": [],
+        "//bazel/constraints:atmega328p": [],
+        "//conditions:default": ["//bazel/constraints:incompatible_mcu"],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":hdrs",

--- a/libs/timer/BUILD
+++ b/libs/timer/BUILD
@@ -13,9 +13,11 @@ cc_library(
     srcs = [
         "timer.c",
     ],
-    target_compatible_with = [
-        "//bazel/constraints:atmega16m1",
-    ],
+    target_compatible_with = select({
+        "//bazel/constraints:atmega16m1": [],
+        "//bazel/constraints:atmega64m1": [],
+        "//conditions:default": ["//bazel/constraints:incompatible_mcu"],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":hdrs",

--- a/libs/uart/BUILD
+++ b/libs/uart/BUILD
@@ -16,7 +16,6 @@ cc_library(
     target_compatible_with = select({
         "//bazel/constraints:atmega16m1": [],
         "//bazel/constraints:atmega64m1": [],
-        "//bazel/constraints:atmega328p": [],
         "//conditions:default": ["//bazel/constraints:incompatible_mcu"],
     }),
     visibility = ["//visibility:public"],

--- a/libs/uart/BUILD
+++ b/libs/uart/BUILD
@@ -13,9 +13,12 @@ cc_library(
     srcs = [
         "uart.c",
     ],
-    target_compatible_with = [
-        "//bazel/constraints:atmega16m1",
-    ],
+    target_compatible_with = select({
+        "//bazel/constraints:atmega16m1": [],
+        "//bazel/constraints:atmega64m1": [],
+        "//bazel/constraints:atmega328p": [],
+        "//conditions:default": ["//bazel/constraints:incompatible_mcu"],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":hdrs",

--- a/scripts/ldscripts/BUILD
+++ b/scripts/ldscripts/BUILD
@@ -2,9 +2,7 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-filegroup(
-    name = "atmega16m1",
-    srcs = [
-        "atmega16m1.ld",
-    ],
-)
+exports_files([
+    "atmega16m1.ld",
+    "atmega64m1.ld",
+])

--- a/scripts/ldscripts/atmega64m1.ld
+++ b/scripts/ldscripts/atmega64m1.ld
@@ -1,0 +1,270 @@
+/* Default linker script, for normal executables */
+/* Copyright (C) 2014-2015 Free Software Foundation, Inc.
+   Copying and distribution of this script, with or without modification,
+   are permitted in any medium without royalty provided the copyright
+   notice and this notice are preserved.  */
+OUTPUT_FORMAT("elf32-avr","elf32-avr","elf32-avr")
+OUTPUT_ARCH(avr:5)
+__TEXT_REGION_ORIGIN__ = DEFINED(__TEXT_REGION_ORIGIN__) ? __TEXT_REGION_ORIGIN__ : 0;
+__DATA_REGION_ORIGIN__ = DEFINED(__DATA_REGION_ORIGIN__) ? __DATA_REGION_ORIGIN__ : 0x800060;
+__TEXT_REGION_LENGTH__ = DEFINED(__TEXT_REGION_LENGTH__) ? __TEXT_REGION_LENGTH__ : 128K;
+__DATA_REGION_LENGTH__ = DEFINED(__DATA_REGION_LENGTH__) ? __DATA_REGION_LENGTH__ : 0xffa0;
+__EEPROM_REGION_LENGTH__ = DEFINED(__EEPROM_REGION_LENGTH__) ? __EEPROM_REGION_LENGTH__ : 64K;
+__FUSE_REGION_LENGTH__ = DEFINED(__FUSE_REGION_LENGTH__) ? __FUSE_REGION_LENGTH__ : 1K;
+__LOCK_REGION_LENGTH__ = DEFINED(__LOCK_REGION_LENGTH__) ? __LOCK_REGION_LENGTH__ : 1K;
+__SIGNATURE_REGION_LENGTH__ = DEFINED(__SIGNATURE_REGION_LENGTH__) ? __SIGNATURE_REGION_LENGTH__ : 1K;
+__USER_SIGNATURE_REGION_LENGTH__ = DEFINED(__USER_SIGNATURE_REGION_LENGTH__) ? __USER_SIGNATURE_REGION_LENGTH__ : 1K;
+MEMORY
+{
+  text   (rx)   : ORIGIN = __TEXT_REGION_ORIGIN__, LENGTH = __TEXT_REGION_LENGTH__
+  data   (rw!x) : ORIGIN = __DATA_REGION_ORIGIN__, LENGTH = __DATA_REGION_LENGTH__
+  eeprom (rw!x) : ORIGIN = 0x810000, LENGTH = __EEPROM_REGION_LENGTH__
+  fuse      (rw!x) : ORIGIN = 0x820000, LENGTH = __FUSE_REGION_LENGTH__
+  lock      (rw!x) : ORIGIN = 0x830000, LENGTH = __LOCK_REGION_LENGTH__
+  signature (rw!x) : ORIGIN = 0x840000, LENGTH = __SIGNATURE_REGION_LENGTH__
+  user_signatures (rw!x) : ORIGIN = 0x850000, LENGTH = __USER_SIGNATURE_REGION_LENGTH__
+}
+SECTIONS
+{
+  /* Read-only sections, merged into text segment: */
+  .image_hdr :
+  {
+    __image_hdr = .;
+    KEEP(*(.image_hdr))
+  } > text
+  .hash          : { *(.hash)		}
+  .dynsym        : { *(.dynsym)		}
+  .dynstr        : { *(.dynstr)		}
+  .gnu.version   : { *(.gnu.version)	}
+  .gnu.version_d   : { *(.gnu.version_d)	}
+  .gnu.version_r   : { *(.gnu.version_r)	}
+  .rel.init      : { *(.rel.init)		}
+  .rela.init     : { *(.rela.init)	}
+  .rel.text      :
+    {
+      *(.rel.text)
+      *(.rel.text.*)
+      *(.rel.gnu.linkonce.t*)
+    }
+  .rela.text     :
+    {
+      *(.rela.text)
+      *(.rela.text.*)
+      *(.rela.gnu.linkonce.t*)
+    }
+  .rel.fini      : { *(.rel.fini)		}
+  .rela.fini     : { *(.rela.fini)	}
+  .rel.rodata    :
+    {
+      *(.rel.rodata)
+      *(.rel.rodata.*)
+      *(.rel.gnu.linkonce.r*)
+    }
+  .rela.rodata   :
+    {
+      *(.rela.rodata)
+      *(.rela.rodata.*)
+      *(.rela.gnu.linkonce.r*)
+    }
+  .rel.data      :
+    {
+      *(.rel.data)
+      *(.rel.data.*)
+      *(.rel.gnu.linkonce.d*)
+    }
+  .rela.data     :
+    {
+      *(.rela.data)
+      *(.rela.data.*)
+      *(.rela.gnu.linkonce.d*)
+    }
+  .rel.ctors     : { *(.rel.ctors)	}
+  .rela.ctors    : { *(.rela.ctors)	}
+  .rel.dtors     : { *(.rel.dtors)	}
+  .rela.dtors    : { *(.rela.dtors)	}
+  .rel.got       : { *(.rel.got)		}
+  .rela.got      : { *(.rela.got)		}
+  .rel.bss       : { *(.rel.bss)		}
+  .rela.bss      : { *(.rela.bss)		}
+  .rel.plt       : { *(.rel.plt)		}
+  .rela.plt      : { *(.rela.plt)		}
+  /* Internal text space or external memory.  */
+  .text   :
+  {
+    *(.vectors)
+    KEEP(*(.vectors))
+    /* For data that needs to reside in the lower 64k of progmem.  */
+     *(.progmem.gcc*)
+    /* PR 13812: Placing the trampolines here gives a better chance
+       that they will be in range of the code that uses them.  */
+    . = ALIGN(2);
+     __trampolines_start = . ;
+    /* The jump trampolines for the 16-bit limited relocs will reside here.  */
+    *(.trampolines)
+     *(.trampolines*)
+     __trampolines_end = . ;
+    /* avr-libc expects these data to reside in lower 64K. */
+     *libprintf_flt.a:*(.progmem.data)
+     *libc.a:*(.progmem.data)
+     *(.progmem*)
+    . = ALIGN(2);
+    /* For future tablejump instruction arrays for 3 byte pc devices.
+       We don't relax jump/call instructions within these sections.  */
+    *(.jumptables)
+     *(.jumptables*)
+    /* For code that needs to reside in the lower 128k progmem.  */
+    *(.lowtext)
+     *(.lowtext*)
+     __ctors_start = . ;
+     *(.ctors)
+     __ctors_end = . ;
+     __dtors_start = . ;
+     *(.dtors)
+     __dtors_end = . ;
+    KEEP(SORT(*)(.ctors))
+    KEEP(SORT(*)(.dtors))
+    /* From this point on, we don't bother about wether the insns are
+       below or above the 16 bits boundary.  */
+    *(.init0)  /* Start here after reset.  */
+    KEEP (*(.init0))
+    *(.init1)
+    KEEP (*(.init1))
+    *(.init2)  /* Clear __zero_reg__, set up stack pointer.  */
+    KEEP (*(.init2))
+    *(.init3)
+    KEEP (*(.init3))
+    *(.init4)  /* Initialize data and BSS.  */
+    KEEP (*(.init4))
+    *(.init5)
+    KEEP (*(.init5))
+    *(.init6)  /* C++ constructors.  */
+    KEEP (*(.init6))
+    *(.init7)
+    KEEP (*(.init7))
+    *(.init8)
+    KEEP (*(.init8))
+    *(.init9)  /* Call main().  */
+    KEEP (*(.init9))
+    *(.text)
+    . = ALIGN(2);
+     *(.text.*)
+    . = ALIGN(2);
+    *(.fini9)  /* _exit() starts here.  */
+    KEEP (*(.fini9))
+    *(.fini8)
+    KEEP (*(.fini8))
+    *(.fini7)
+    KEEP (*(.fini7))
+    *(.fini6)  /* C++ destructors.  */
+    KEEP (*(.fini6))
+    *(.fini5)
+    KEEP (*(.fini5))
+    *(.fini4)
+    KEEP (*(.fini4))
+    *(.fini3)
+    KEEP (*(.fini3))
+    *(.fini2)
+    KEEP (*(.fini2))
+    *(.fini1)
+    KEEP (*(.fini1))
+    *(.fini0)  /* Infinite loop after program termination.  */
+    KEEP (*(.fini0))
+     _etext = . ;
+  }  > text
+  .data          :
+  {
+     PROVIDE (__data_start = .) ;
+    *(.data)
+     *(.data*)
+    *(.gnu.linkonce.d*)
+    *(.rodata)  /* We need to include .rodata here if gcc is used */
+     *(.rodata*) /* with -fdata-sections.  */
+    *(.gnu.linkonce.r*)
+    . = ALIGN(2);
+     _edata = . ;
+     PROVIDE (__data_end = .) ;
+  }  > data AT> text
+  .bss  ADDR(.data) + SIZEOF (.data)   : AT (ADDR (.bss))
+  {
+     PROVIDE (__bss_start = .) ;
+    *(.bss)
+     *(.bss*)
+    *(COMMON)
+     PROVIDE (__bss_end = .) ;
+  }  > data
+   __data_load_start = LOADADDR(.data);
+   __data_load_end = __data_load_start + SIZEOF(.data);
+  /* Global data not cleared after reset.  */
+  .noinit  ADDR(.bss) + SIZEOF (.bss)  :  AT (ADDR (.noinit))
+  {
+     PROVIDE (__noinit_start = .) ;
+    *(.noinit*)
+     PROVIDE (__noinit_end = .) ;
+     _end = . ;
+     PROVIDE (__heap_start = .) ;
+  }  > data
+  .eeprom  :
+  {
+    /* See .data above...  */
+    KEEP(*(.eeprom*))
+     __eeprom_end = . ;
+  }  > eeprom
+  .fuse  :
+  {
+    KEEP(*(.fuse))
+    KEEP(*(.lfuse))
+    KEEP(*(.hfuse))
+    KEEP(*(.efuse))
+  }  > fuse
+  .lock  :
+  {
+    KEEP(*(.lock*))
+  }  > lock
+  .signature  :
+  {
+    KEEP(*(.signature*))
+  }  > signature
+  .user_signatures  :
+  {
+    KEEP(*(.user_signatures*))
+  }  > user_signatures
+  /* Stabs debugging sections.  */
+  .stab 0 : { *(.stab) }
+  .stabstr 0 : { *(.stabstr) }
+  .stab.excl 0 : { *(.stab.excl) }
+  .stab.exclstr 0 : { *(.stab.exclstr) }
+  .stab.index 0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment 0 : { *(.comment) }
+  .note.gnu.build-id : { *(.note.gnu.build-id) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end ) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  /* DWARF Extension.  */
+  .debug_macro    0 : { *(.debug_macro) }
+}

--- a/vehicle/mkv/software/air_control/BUILD
+++ b/vehicle/mkv/software/air_control/BUILD
@@ -15,9 +15,11 @@ cc_firmware(
         "air.c",
         "air_config.h",
     ],
-    target_compatible_with = [
-        "//bazel/constraints:atmega16m1",
-    ],
+    target_compatible_with = select({
+        "//bazel/constraints:atmega16m1": [],
+        "//bazel/constraints:atmega64m1": [],
+        "//conditions:default": ["//bazel/constraints:incompatible_mcu"],
+    }),
     deps = [
         ":can_api",
         ":utils",
@@ -36,9 +38,11 @@ cc_library(
         "utils/timer.h",
         "utils/utils.h",
     ],
-    target_compatible_with = [
-        "//bazel/constraints:atmega16m1",
-    ],
+    target_compatible_with = select({
+        "//bazel/constraints:atmega16m1": [],
+        "//bazel/constraints:atmega64m1": [],
+        "//conditions:default": ["//bazel/constraints:incompatible_mcu"],
+    }),
     visibility = ["//visibility:private"],
     deps = [
         ":can_api",

--- a/vehicle/mkv/software/air_control/air_config.h
+++ b/vehicle/mkv/software/air_control/air_config.h
@@ -7,16 +7,8 @@
  * GPIO pin definitions
  */
 
-// #define BOARD_16M1_HACKER
-#define BOARD_SERVICE_SECTION_CONTROLLER
-
-#ifdef BOARD_SERVICE_SECTION_CONTROLLER
-// Outputs
 gpio_t PRECHARGE_CTL = PB2;
 gpio_t AIR_N_LSD = PC6;
-
-gpio_t FAULT_LED = PD6;
-gpio_t GENERAL_LED = PD7;
 
 // Inputs
 gpio_t SS_TSMS = PB3;
@@ -27,30 +19,21 @@ gpio_t SS_HVD = PB7;
 
 gpio_t BMS_SENSE = PC0;
 gpio_t AIR_P_WELD_DETECT = PC4;
-gpio_t AIR_N_WELD_DETECT = PC5;
 
 gpio_t IMD_SENSE = PD0;
 
-#elif defined(BOARD_16M1_HACKER)
-// Outputs
-gpio_t PRECHARGE_CTL = PB2;
-gpio_t AIR_N_LSD = PC6;
+#ifdef BOARD_HACKERBOARD
+
+gpio_t FAULT_LED = PD6;
+gpio_t GENERAL_LED = PD7;
+gpio_t AIR_N_WELD_DETECT = PC5;
+
+#else
 
 gpio_t FAULT_LED = PB7;
 gpio_t GENERAL_LED = PD6;
-
-// Inputs
-gpio_t SS_TSMS = PB3;
-gpio_t SS_IMD_LATCH = PB4;
-gpio_t SS_MPC = PB5;
-gpio_t SS_HVD_CONN = PB6;
-gpio_t SS_HVD = PD7;
-
-gpio_t BMS_SENSE = PC0;
-gpio_t AIR_P_WELD_DETECT = PC4;
 gpio_t AIR_N_WELD_DETECT = PC7;
 
-gpio_t IMD_SENSE = PD0;
 #endif
 
 #define BMS_VOLTAGE_THRESHOLD_LOW_daV     (20) // 20 decavolts (200 volts)


### PR DESCRIPTION
Adds Bazel support for ATMega64m1, as well as platforms like `firmware-hitl-test` and `hackerboard`.