### PR TITLE
Modify BMS temperature to use asynchronous architecture

### DIFF
--- a/vehicle/mkv/software/bms/bms.c
+++ b/vehicle/mkv/software/bms/bms.c
@@ -24,6 +24,7 @@ enum State {
 };
 
 enum AIR_State {
+    AIR_STATE_INIT,
     AIR_STATE_IDLE,
     AIR_STATE_SHUTDOWN_CIRCUIT_CLOSED,
     AIR_STATE_PRECHARGE,
@@ -213,7 +214,7 @@ static void state_machine_run(void) {
                 bms_core.bms_state = FAULT;
             }
 
-            if (air_state != AIR_STATE_IDLE) {
+            if ((air_state != AIR_STATE_IDLE) && (air_state != AIR_STATE_INIT) && (air_state != AIR_STATE_FAULT)) {
                 bms_core.bms_state = DISCHARGING;
             }
 

--- a/vehicle/mkv/software/bms/bms.c
+++ b/vehicle/mkv/software/bms/bms.c
@@ -107,11 +107,11 @@ static int initial_checks(void) {
     bms_sense.min_temperature = min_temp;
     bms_sense.max_temperature = max_temp;
 
-    if (ut > 0) {
+    if (ut > MAX_EXTRANEOUS_TEMPERATURES) {
         set_fault(BMS_FAULT_UNDERTEMPERATURE);
         rc = 1;
         goto bail;
-    } else if (ot > 0) {
+    } else if (ot > MAX_EXTRANEOUS_TEMPERATURES) {
         set_fault(BMS_FAULT_OVERTEMPERATURE);
         rc = 1;
         goto bail;
@@ -168,17 +168,15 @@ static void state_machine_run(void) {
     bms_sense.min_temperature = min_temp;
     bms_sense.max_temperature = max_temp;
 
-    // bms_core.pack_temperature = pack_temperature;
-
-    // if (ut > MAX_EXTRANEOUS_TEMPERATURES) {
-    //     set_fault(BMS_FAULT_UNDERTEMPERATURE);
-    //     bms_core.bms_state = FAULT;
-    //     return;
-    // } else if (ot > MAX_EXTRANEOUS_TEMPERATURES) {
-    //     set_fault(BMS_FAULT_OVERTEMPERATURE);
-    //     bms_core.bms_state = FAULT;
-    //     return;
-    // }
+    if (ut > MAX_EXTRANEOUS_TEMPERATURES) {
+        set_fault(BMS_FAULT_UNDERTEMPERATURE);
+        bms_core.bms_state = FAULT;
+        return;
+    } else if (ot > MAX_EXTRANEOUS_TEMPERATURES) {
+        set_fault(BMS_FAULT_OVERTEMPERATURE);
+        bms_core.bms_state = FAULT;
+        return;
+    }
 
     /*
      * Check for PEC errors

--- a/vehicle/mkv/software/bms/bms.c
+++ b/vehicle/mkv/software/bms/bms.c
@@ -59,46 +59,10 @@ void pcint2_callback(void) {
 /*
  * Perform initial startup checks on the BMS.
  *
- * - Runs BIST (built-in self test) in all the ICs
  * - Checks all temperatures and voltages and ensures they are in range
  */
 static int initial_checks(void) {
     int rc = 0;
-
-    // wakeup_idle(NUM_ICS);
-    // wakeup_sleep(NUM_ICS);
-    /* LTC6811_diagn(); */
-    /*  */
-    /* for (uint8_t ic = 0; ic < NUM_ICS; ic++) { */
-    /*     if (ICS[ic].stat.mux_fail[0] == 1) { */
-    /*         set_fault(BMS_FAULT_DIAGNOSTICS_FAIL); */
-    /*         rc = 1; */
-    /*         goto bail; */
-    /*     } */
-    /* } */
-
-    /*
-     * Run all LTC6811 self-tests
-     *
-     * TODO: not working
-     */
-    // wakeup_sleep(NUM_ICS);
-    // rc += LTC6811_run_cell_adc_st(CELL, NUM_ICS, ICS, MD_7KHZ_3KHZ, 0);
-    // can_send_bms_debug();
-    //
-    // wakeup_sleep(NUM_ICS);
-    // rc += LTC6811_run_cell_adc_st(AUX, NUM_ICS, ICS, MD_7KHZ_3KHZ, 0);
-    // can_send_bms_debug();
-    //
-    // wakeup_sleep(NUM_ICS);
-    // rc += LTC6811_run_cell_adc_st(STAT, NUM_ICS, ICS, MD_7KHZ_3KHZ, 0);
-    // can_send_bms_debug();
-    //
-    //
-    // if (rc != 0) {
-    //     set_fault(BMS_FAULT_DIAGNOSTICS_FAIL);
-    //     goto bail;
-    // }
 
     // read all voltages
     uint32_t ov = 0;
@@ -393,8 +357,6 @@ int main(void) {
             // Every 500ms send sensing and debug data
             if (loop_counter == 50) {
                 can_send_bms_debug();
-                // can_send_bms_voltages();
-                // can_send_bms_temperatures();
                 can_send_bms_metrics();
 
                 loop_counter = 0;

--- a/vehicle/mkv/software/bms/bms.c
+++ b/vehicle/mkv/software/bms/bms.c
@@ -104,6 +104,9 @@ static int initial_checks(void) {
         bms_metrics.temperature_pec_error_count += rc;
     }
 
+    bms_sense.min_temperature = min_temp;
+    bms_sense.max_temperature = max_temp;
+
     if (ut > 0) {
         set_fault(BMS_FAULT_UNDERTEMPERATURE);
         rc = 1;
@@ -161,6 +164,10 @@ static void state_machine_run(void) {
 
     // uint16_t pack_temperature;
     rc = temperature_task(&ot, &ut, &min_temp, &max_temp);
+
+    bms_sense.min_temperature = min_temp;
+    bms_sense.max_temperature = max_temp;
+
     // bms_core.pack_temperature = pack_temperature;
 
     // if (ut > MAX_EXTRANEOUS_TEMPERATURES) {
@@ -325,6 +332,7 @@ int main(void) {
     }
 
     can_send_bms_core();
+    can_send_bms_sense();
 
     // Turn off GENERAL_LED to indicate checks passed
     gpio_clear_pin(GENERAL_LED);
@@ -345,6 +353,7 @@ int main(void) {
 
         if (run_10ms) {
             can_send_bms_core();
+            can_send_bms_sense();
             can_send_bms_metrics();
             state_machine_run();
 

--- a/vehicle/mkv/software/bms/bms.yml
+++ b/vehicle/mkv/software/bms/bms.yml
@@ -104,14 +104,14 @@ publish:
       - name: min_temperature
         slice: 0 + 16
         unit:
-          type: int16_t
+          type: uint16_t
           name: V
           offset: 0
           scale: 0.0001
       - name: max_temperature
         slice: 16 + 16
         unit:
-          type: int16_t
+          type: uint16_t
           name: V
           offset: 0
           scale: 0.0001

--- a/vehicle/mkv/software/bms/bms.yml
+++ b/vehicle/mkv/software/bms/bms.yml
@@ -44,14 +44,14 @@ publish:
         slice: 24 + 8
         unit:
           type: uint8_t
-          name: degC
+          name: V
           offset: 0
           scale: 0.0001
       - name: max_temperature
         slice: 32 + 8
         unit:
           type: uint8_t
-          name: degC
+          name: V
           offset: 0
           scale: 0.0001
       - name: pack_current
@@ -82,27 +82,39 @@ publish:
           values:
             t: Current limiting enabled
             f: Current limiting disabled
-      - name: relay_status
-        slice: 55 + 1
-        unit:
-          type: bool
-          values:
-            t: BMS relay closed
-            f: BMS relay open
       - name: bspd_current_sense
-        slice: 56 + 1
+        slice: 55 + 1
         unit:
           type: bool
           values:
             t: Current sensed
             f: No current sensed
       - name: overcurrent_detect
-        slice: 57 + 1
+        slice: 56 + 1
         unit:
           type: bool
           values:
             t: Over-current detected
             f: No over-current detected
+
+  - name: bms_sense
+    id: 0x011
+    freq_hz: 100
+    signals:
+      - name: min_temperature
+        slice: 0 + 16
+        unit:
+          type: int16_t
+          name: V
+          offset: 0
+          scale: 0.0001
+      - name: max_temperature
+        slice: 16 + 16
+        unit:
+          type: int16_t
+          name: V
+          offset: 0
+          scale: 0.0001
 
   - name: bms_metrics
     id: 0x510

--- a/vehicle/mkv/software/bms/bms.yml
+++ b/vehicle/mkv/software/bms/bms.yml
@@ -40,57 +40,43 @@ publish:
           name: V
           offset: 0
           scale: 0.0001 * 256
-      - name: min_temperature
-        slice: 24 + 8
-        unit:
-          type: uint8_t
-          name: V
-          offset: 0
-          scale: 0.0001
-      - name: max_temperature
-        slice: 32 + 8
-        unit:
-          type: uint8_t
-          name: V
-          offset: 0
-          scale: 0.0001
       - name: pack_current
-        slice: 40 + 12
+        slice: 24 + 12
         unit:
           type: int16_t
           name: A
           offset: 0
           scale: 1
       - name: cell_balancing_status
-        slice: 52 + 1
+        slice: 36 + 1
         unit:
           type: bool
           values:
             t: Cell balancing enabled
             f: Cell balancing disabled
       - name: regen_enabled
-        slice: 53 + 1
+        slice: 37 + 1
         unit:
           type: bool
           values:
             t: Regenerative braking enabled
             f: Regenerative braking disabled
       - name: current_limiting_enabled
-        slice: 54 + 1
+        slice: 38 + 1
         unit:
           type: bool
           values:
             t: Current limiting enabled
             f: Current limiting disabled
       - name: bspd_current_sense
-        slice: 55 + 1
+        slice: 39 + 1
         unit:
           type: bool
           values:
             t: Current sensed
             f: No current sensed
       - name: overcurrent_detect
-        slice: 56 + 1
+        slice: 40 + 1
         unit:
           type: bool
           values:

--- a/vehicle/mkv/software/bms/bms.yml
+++ b/vehicle/mkv/software/bms/bms.yml
@@ -40,10 +40,17 @@ publish:
           name: V
           offset: 0
           scale: 0.0001 * 256
-      - name: pack_temperature
-        slice: 24 + 16
+      - name: min_temperature
+        slice: 24 + 8
         unit:
-          type: int16_t
+          type: uint8_t
+          name: degC
+          offset: 0
+          scale: 0.0001
+      - name: max_temperature
+        slice: 32 + 8
+        unit:
+          type: uint8_t
           name: degC
           offset: 0
           scale: 0.0001

--- a/vehicle/mkv/software/bms/bms_config.h
+++ b/vehicle/mkv/software/bms/bms_config.h
@@ -20,7 +20,7 @@
 #define NUM_CELLS (12)
 
 #define OVERVOLTAGE_THRESHOLD  (42000) // 4.2V
-#define UNDERVOLTAGE_THRESHOLD (29000) // 3.0V
+#define UNDERVOLTAGE_THRESHOLD (30000) // 3.0V
 
 /*
  * We can handle missing around 5 temperatures, since we know there will be some

--- a/vehicle/mkv/software/bms/bms_config.h
+++ b/vehicle/mkv/software/bms/bms_config.h
@@ -19,7 +19,6 @@
 // Number of cells that can be measured
 #define NUM_CELLS (12)
 
-// TODO verify over/under voltage/temperature thresholds
 #define OVERVOLTAGE_THRESHOLD  (42000) // 4.2V
 #define UNDERVOLTAGE_THRESHOLD (29000) // 3.0V
 
@@ -29,11 +28,10 @@
  */
 #define MAX_EXTRANEOUS_TEMPERATURES (5)
 
-#define OVERTEMPERATURE_THRESHOLD      (728) // 60 degC
-#define SOFT_OVERTEMPERATURE_THRESHOLD (1255) // 45 degC
-#define SOFT_OVERTEMPERATURE_THRESHOLD_LOW \
-    (SOFT_OVERTEMPERATURE_THRESHOLD + 500) // TODO degC
-#define UNDERTEMPERATURE_THRESHOLD (7384) // 0 degC
+#define OVERTEMPERATURE_THRESHOLD          ((int16_t)714) // 60 degC
+#define SOFT_OVERTEMPERATURE_THRESHOLD     ((int16_t)1233) // 45 degC
+#define SOFT_OVERTEMPERATURE_THRESHOLD_LOW ((int16_t)1814) // 35 degC
+#define UNDERTEMPERATURE_THRESHOLD         ((int16_t)15513) // -20 degC
 
 #define MAX_PEC_RETRY    (10) // Arbitrary for now
 #define MAX_PEC_IN_A_ROW (32) // Arbitrary for now

--- a/vehicle/mkv/software/bms/tasks/tasks.h
+++ b/vehicle/mkv/software/bms/tasks/tasks.h
@@ -44,6 +44,3 @@ int openwire_task(void);
  * Task to read current from current sensor
  */
 void current_task(int16_t* current);
-
-void can_send_bms_voltages(void);
-void can_send_bms_temperatures(void);

--- a/vehicle/mkv/software/bms/tasks/tasks.h
+++ b/vehicle/mkv/software/bms/tasks/tasks.h
@@ -30,8 +30,7 @@ int voltage_task(uint16_t* pack_voltage, uint32_t* ov, uint32_t* uv);
  * This function handles communication with multiplexers, ADC reading, and
  * temperature accumulating
  */
-int temperature_task(uint16_t* avg_pack_temperature, uint32_t* ot,
-                     uint32_t* ut);
+int temperature_task(uint32_t* ot, uint32_t* ut, int16_t* min_temp, int16_t* max_temp);
 
 /*
  * Task to check for open-wires between the BMS peipherals and the cells

--- a/vehicle/mkv/software/bms/tasks/tasks.h
+++ b/vehicle/mkv/software/bms/tasks/tasks.h
@@ -30,7 +30,8 @@ int voltage_task(uint16_t* pack_voltage, uint32_t* ov, uint32_t* uv);
  * This function handles communication with multiplexers, ADC reading, and
  * temperature accumulating
  */
-int temperature_task(uint32_t* ot, uint32_t* ut, int16_t* min_temp, int16_t* max_temp);
+int temperature_task(uint32_t* ot, uint32_t* ut, int16_t* min_temp,
+                     int16_t* max_temp);
 
 /*
  * Task to check for open-wires between the BMS peipherals and the cells

--- a/vehicle/mkv/software/bms/tasks/temperature_task.c
+++ b/vehicle/mkv/software/bms/tasks/temperature_task.c
@@ -17,127 +17,162 @@ const uint8_t MUXES[NUM_MUXES] = { LTC1380_MUX1, LTC1380_MUX2, LTC1380_MUX3 };
  * Enables or disables the accumulator fans by turning on or off the PWM pin
  * connected to timer 1.
  */
-// static void fan_enable(bool enable) {
-//     timer1_fan_cfg.channel_b.pin_behavior = enable ? TOGGLE : DISCONNECTED;
-//
-//     // No way to update a single part of the config so we just re-init the
-//     timer timer_init(&timer1_fan_cfg);
-// }
+static void fan_enable(bool enable) {
+    timer1_fan_cfg.channel_b.pin_behavior = enable ? TOGGLE : DISCONNECTED;
 
-int temperature_task(uint16_t* avg_pack_temperature, uint32_t* ot,
-                     uint32_t* ut) {
+    // No way to update a single part of the config so we just re-init the 
+    // timer
+    timer_init(&timer1_fan_cfg);
+}
+
+/*
+ * Here, min and max refer to the voltages of the divider, NOT the actual
+ * temperatures. We are using negative-temperature-coefficient thermistors, so
+ * the lower the voltage, the higher the temperature. Keep this in mind when
+ * reading through the code.
+ *
+ * We initialize the min_temp to the MAXIMUM value for an int16_t so that the
+ * first time it runs, the min voltage will always be smaller. We do the same
+ * for the max_temp.
+ */
+int16_t min_temperature = INT16_MAX;
+int16_t max_temperature = INT16_MIN;
+
+uint8_t can_data[8] = { 0 };
+
+can_frame_t temperature_frame = {
+    .id = CAN_TOOLS_BMS_TEMPERATURE_FRAME_ID,
+    .mob = 0,
+    .dlc = CAN_TOOLS_BMS_TEMPERATURE_LENGTH,
+    .data = can_data,
+};
+
+int temperature_task(uint32_t* ot, uint32_t* ut, int16_t* min_temp, int16_t* max_temp) {
     int pec_errors = 0;
-    int32_t cumulative_temperature = 0;
 
+    static uint8_t mux = 0;
+    static uint8_t channel = 0;
+
+    if ((mux == 0) && (channel == 0)) {
+        /*
+         * Reset the min and max temperatures each time we start over
+         *
+         * See the commment about regarding why we set min to MAX and vice 
+         * versa
+         */
+        min_temperature = INT16_MAX;
+        max_temperature = INT16_MIN;
+    }
+
+    // Set mux and channel in CAN message
+    can_data[1] = (mux & 0xF) | ((channel & 0xF) << 4);
+
+    // We store temperatures within the CAN data array starting at index 2
+    uint16_t* temperatures = (uint16_t *)&can_data[2];
+
+    /*
+     * Wake up the LTC6811s
+     */
     wakeup_sleep(NUM_ICS);
 
-    for (uint8_t mux = 0; mux < NUM_MUXES; mux++) {
-        // For each mux,
-        for (uint8_t ch = 0; ch < NUM_MUX_CHANNELS; ch++) {
-            // For each mux channel (ch)
+    {
+        enable_mux(NUM_ICS, MUXES[mux], MUX_ENABLE, channel);
 
-            enable_mux(NUM_ICS, MUXES[mux], MUX_ENABLE, ch);
+        // Read aux gpio voltage (this is what the tmperature sensor is
+        // connected to) for temperature
+        wakeup_idle(NUM_ICS);
+        LTC6811_adax(MD_7KHZ_3KHZ, AUX_CH_GPIO1);
 
-            // Read aux gpio voltage (this is what the tmperature sensor is
-            // connected to) for temperature
-            wakeup_idle(NUM_ICS);
-            LTC6811_adax(MD_7KHZ_3KHZ, AUX_CH_GPIO1);
+        // Wait for conversions to finish
+        (void)LTC6811_pollAdc();
 
-            // Wait for conversions to finish
-            (void)LTC6811_pollAdc();
+        // Raw (iso)SPI data
+        uint8_t raw_data[NUM_RX_BYT * NUM_ICS];
 
-            uint8_t raw_data[NUM_RX_BYT * NUM_ICS]; // raw data read back
+        wakeup_idle(NUM_ICS);
+        LTC681x_rdaux_reg(AUX_CH_GPIO1, NUM_ICS, raw_data);
 
-            wakeup_idle(NUM_ICS);
-            LTC681x_rdaux_reg(AUX_CH_GPIO1, NUM_ICS, raw_data);
+        // Stores the current temperatures index in the CAN message Used to
+        // indicate when a CAN message should be sent: When this number 
+        // reaches 3, we send the CAN message and reset it to zero
+        uint8_t can_temperature_index = 0;
 
-            can_frame_t temperature_frame = {
-                .id = CAN_TOOLS_BMS_TEMPERATURE_FRAME_ID,
-                .mob = 0,
-                .dlc = CAN_TOOLS_BMS_TEMPERATURE_LENGTH,
-            };
+        for (uint8_t ic = 0; ic < NUM_ICS; ic++) {
+            if (ic % 2 == 1) {
+                // Skip all odd ICs
+                continue;
+            }
 
-            uint8_t can_data[8] = { 0 };
-            uint16_t* temperatures = (uint16_t*)&(can_data[2]);
+            if (ic < 5) {
+                can_data[0] = 0;
+            } else {
+                can_data[0] = 1;
+            }
 
-            can_data[1] = (mux & 0xF) | ((ch & 0xF) << 4);
-            temperature_frame.data = can_data;
+            // Used to get the value of the ADC from the raw data, since data
+            // contains the voltages from all of the LTC6811s
+            uint16_t data_counter = ic * NUM_RX_BYT;
 
-            uint8_t temperature_idx_counter = 0;
+            // The voltage value from the ADC is in the zeroth "word" (two
+            // bytes) of the response data
+            uint16_t temperature = raw_data[data_counter]
+                                   | (raw_data[data_counter + 1] << 8);
 
-            for (uint8_t ic = 0; ic < NUM_ICS; ic++) {
-                if (ic % 2 == 1) {
-                    // Skip all odd ICs
-                    continue;
-                }
+            temperatures[can_temperature_index] = temperature;
 
-                if (ic < 5) {
-                    can_data[0] = 0;
-                } else {
-                    can_data[0] = 1;
-                }
-
-                uint16_t data_counter = (ic)*NUM_RX_BYT;
-
-                // The voltage value from the ADC is in the zeroth "word" (two
-                // bytes) of the response data
-                uint16_t temperature = raw_data[data_counter]
-                                       | (raw_data[data_counter + 1] << 8);
-
-                temperatures[temperature_idx_counter] = temperature;
-
-                temperature_idx_counter++;
-
-                if (temperature_idx_counter == 3) {
-                    can_send(&temperature_frame); // TODO: use cantools?
-                    temperature_idx_counter = 0;
-                }
-
-                // TODO: calc PEC
-
-                cumulative_temperature += temperature;
-
-                /*
-                 * Using negative-temperature-coefficient (NTC) thermistors, so
-                 * comparisons are reversed (i.e. less than over-temp threshold)
-                 */
-                // if (temperature < OVERTEMPERATURE_THRESHOLD) {
-                //     *ot += 1;
-                // }
-                //
-                // /*
-                //  * If temperatures are getting a bit too high, we turn on the
-                //  * fan
-                //  */
-                // if (temperature < SOFT_OVERTEMPERATURE_THRESHOLD) {
-                //     fan_enable(true);
-                // }
-                //
-                // if (temperature > SOFT_OVERTEMPERATURE_THRESHOLD_LOW) {
-                //     fan_enable(false);
-                // }
-                //
-                // if (temperature > UNDERTEMPERATURE_THRESHOLD) {
-                //     *ut += 1;
-                // }
+            if (can_temperature_index == 3) {
+                can_send(&temperature_frame);
+                can_temperature_index = 0;
             }
 
             /*
-             * Compute average temperature. This truncates a 32 bit number
-             * into a 16 bit number. This shouldn't be a problem because the
-             * average temperature won't be larger than 16-bits, but the reader
-             * should be aware that this is intentional. A 32 bit number is
-             * needed to store the cumulative sum, and it can be shown that this
-             * is sufficient to store the sum of all the temperature sensor
-             * voltages
+             * Update temperature mins and maxes
              */
-            *avg_pack_temperature
-                = (cumulative_temperature
-                   / (NUM_MUXES * NUM_MUX_CHANNELS * NUM_TEMPERATURE_ICS));
+            if (temperature < min_temperature) {
+                min_temperature = temperature;
+                *min_temp = min_temperature;
+            }
 
-            enable_mux(NUM_ICS, MUXES[mux], MUX_DISABLE, ch);
-        } // End for each mux channel
-    } // End for each mux
+            if (temperature > max_temperature) {
+                max_temperature = temperature;
+                *max_temp = max_temperature;
+            }
+
+            // TODO: calc PEC
+        }
+    }
+
+    // Increment mux and channel as necessary
+    channel = (channel + 1) % NUM_MUX_CHANNELS;
+
+    if (channel == 0) {
+        enable_mux(NUM_ICS, MUXES[mux], MUX_DISABLE, channel);
+        mux = (mux + 1) % NUM_MUXES;
+    }
+
+    /*
+     * Using negative-temperature-coefficient (NTC) thermistors, so
+     * comparisons are reversed (i.e. less than over-temp threshold)
+     */
+    if (min_temperature < OVERTEMPERATURE_THRESHOLD) {
+        *ot += 1;
+    }
+    
+    /*
+     * If temperatures are getting a bit too high, we turn on the
+     * fan
+     */
+    if (min_temperature < SOFT_OVERTEMPERATURE_THRESHOLD) {
+        fan_enable(true);
+    }
+    
+    if (max_temperature > SOFT_OVERTEMPERATURE_THRESHOLD_LOW) {
+        fan_enable(false);
+    }
+    
+    if (max_temperature > UNDERTEMPERATURE_THRESHOLD) {
+        *ut += 1;
+    }
 
     return pec_errors;
 }

--- a/vehicle/mkv/software/bms/tasks/temperature_task.c
+++ b/vehicle/mkv/software/bms/tasks/temperature_task.c
@@ -13,11 +13,6 @@ const uint8_t MUXES[NUM_MUXES] = { LTC1380_MUX1, LTC1380_MUX2, LTC1380_MUX3 };
 #define NUM_TEMPS_PER_MESSAGE   (4)
 #define NUM_CAN_TEMP_MSG_PER_IC (6)
 
-// #define CAN_TEMP_MESSAGE_BASE (CAN_TOOLS_BMS_SEGMENT1_TEMPERATURE1_FRAME_ID)
-// #define CAN_TEMP_DLC          (CAN_TOOLS_BMS_SEGMENT1_TEMPERATURE1_LENGTH)
-
-// static uint16_t temperatures[NUM_TEMPERATURE_ICS][NUM_TEMPS_PER_IC] = { 0 };
-
 /*
  * Enables or disables the accumulator fans by turning on or off the PWM pin
  * connected to timer 1.
@@ -41,18 +36,15 @@ int temperature_task(uint16_t* avg_pack_temperature, uint32_t* ot,
         for (uint8_t ch = 0; ch < NUM_MUX_CHANNELS; ch++) {
             // For each mux channel (ch)
 
-            // enable_mux(NUM_ICS, MUXES[mux], MUX_DISABLE, ch-1);
             enable_mux(NUM_ICS, MUXES[mux], MUX_ENABLE, ch);
 
-            // read aux gpio voltage (this is what the tmperature sensor is
+            // Read aux gpio voltage (this is what the tmperature sensor is
             // connected to) for temperature
             wakeup_idle(NUM_ICS);
             LTC6811_adax(MD_7KHZ_3KHZ, AUX_CH_GPIO1);
 
             // Wait for conversions to finish
             (void)LTC6811_pollAdc();
-
-            // Read voltage from auxiliary pin (connected to the mux)
 
             uint8_t raw_data[NUM_RX_BYT * NUM_ICS]; // raw data read back
 
@@ -85,10 +77,7 @@ int temperature_task(uint16_t* avg_pack_temperature, uint32_t* ot,
                     can_data[0] = 1;
                 }
 
-                // Executes for every other chip (0, 2, 4, etc)
-
                 uint16_t data_counter = (ic)*NUM_RX_BYT;
-                // uint16_t temperature_idx = mux * NUM_MUX_CHANNELS + ch;
 
                 // The voltage value from the ADC is in the zeroth "word" (two
                 // bytes) of the response data
@@ -152,43 +141,3 @@ int temperature_task(uint16_t* avg_pack_temperature, uint32_t* ot,
 
     return pec_errors;
 }
-
-// void can_send_bms_temperatures(void) {
-//     can_frame_t temperature_frame = {
-//         .id = CAN_TOOLS_BMS_TEMPERATURE_FRAME_ID,
-//         .mob = 0,
-//         .dlc = CAN_TOOLS_BMS_TEMPERATURE_LENGTH,
-//     };
-//
-//     for (uint8_t temp_ic = 0; temp_ic < NUM_TEMPERATURE_ICS; temp_ic++) {
-//         /*
-//          * NUM_MUXES = 3
-//          * NUM_MUX_CHANNELS = 8
-//          * 3 * 8 = 24 total channels per peripheral board
-//          *
-//          * Each CAN message can send 8 bytes, or 4 temperatures (each temp is
-//          2
-//          *     bytes)
-//          *
-//          * Need 6 CAN messages per board (per iteration of ic)
-//          */
-//         for (uint8_t message = 0; message < NUM_CAN_TEMP_MSG_PER_IC;
-//              message++) {
-//             // For each group of temperatures
-//
-//             /*
-//              * Trick: instead of creating our own data array, we just set the
-//              * pointer to the array to be the pointer to the cell temps in
-//              * giant array with some offset. That way, we can reuse memory
-//              and
-//              * avoid memcpy-ing.
-//              */
-//             temperature_frame.data
-//                 = ((uint8_t*)temperatures[temp_ic]) + (message *
-//                 CAN_TEMP_DLC);
-//
-//             can_send(&temperature_frame);
-//             temperature_frame.id++;
-//         }
-//     }
-// }

--- a/vehicle/mkv/software/bms/tasks/temperature_task.c
+++ b/vehicle/mkv/software/bms/tasks/temperature_task.c
@@ -124,6 +124,22 @@ int temperature_task(uint32_t* ot, uint32_t* ut, int16_t* min_temp,
             }
 
             /*
+             * Hack: There are some broken thermistors, so we skip bounds
+             * checking on them here
+             */
+            if ((mux == 0) && (channel == 5) && (can_temperature_index == 1)) {
+                continue;
+            }
+
+            if ((mux == 2) && (channel == 7) && (can_temperature_index == 1)) {
+                continue;
+            }
+
+            if ((mux == 1) && (channel == 3) && (can_temperature_index == 1)) {
+                continue;
+            }
+
+            /*
              * Update temperature mins and maxes
              *
              * Note: inverted logic

--- a/vehicle/mkv/software/bms/tasks/voltage_task.c
+++ b/vehicle/mkv/software/bms/tasks/voltage_task.c
@@ -40,8 +40,6 @@ int voltage_task(uint16_t* pack_voltage, uint32_t* ov, uint32_t* uv) {
         LTC681x_rdcv_reg(cell_reg + 1, NUM_ICS, raw_data);
 
         for (uint8_t ic = 0; ic < NUM_ICS; ic++) { // foreach LTC6811
-            uint16_t data_counter = ic * NUM_RX_BYT;
-
             can_frame_t voltage_frame = {
                 .id = CAN_TOOLS_BMS_VOLTAGE_FRAME_ID,
                 .mob = 0,
@@ -53,35 +51,64 @@ int voltage_task(uint16_t* pack_voltage, uint32_t* ov, uint32_t* uv) {
             can_data[0] = ic;
             can_data[1] = cell_reg;
             uint16_t* reg_voltages = (uint16_t*)&(can_data[2]);
-
             voltage_frame.data = (uint8_t*)can_data;
 
-            for (uint8_t cell_counter = 0; cell_counter < NUM_CELLS_IN_REG;
-                 cell_counter++) {
-                if (((cell_reg == 1) || (cell_reg == 3))
-                    && (cell_counter >= 1)) {
-                    data_counter += 2;
-                    continue;
-                }
+            uint8_t raw_idx = ic * NUM_RX_BYT;
 
-                // Parse cell voltage
-                uint16_t cell_voltage = raw_data[data_counter]
-                                        + (raw_data[data_counter + 1] << 8);
+            // Get cell voltages
+            uint16_t cell_1
+                = raw_data[raw_idx + 0] + (raw_data[raw_idx + 1] << 8);
+            uint16_t cell_2
+                = raw_data[raw_idx + 2] + (raw_data[raw_idx + 3] << 8);
+            uint16_t cell_3
+                = raw_data[raw_idx + 4] + (raw_data[raw_idx + 5] << 8);
 
-                reg_voltages[cell_counter] = cell_voltage;
+            /*
+             * HACK: There is a bad solder joint somewhere that makes one of our
+             * voltage groups misbehave. Two of the cells read too high and one
+             * reads too low. Until this is fixed, we just average them and
+             * report the average instead
+             */
+            if ((cell_reg == 2) && (ic == 5)) {
+                uint32_t average = (cell_1 + cell_2 + cell_3) / 3;
+                cell_1 = (uint16_t)average;
+                cell_2 = (uint16_t)average;
+                cell_3 = (uint16_t)average;
+            }
 
-                // Accumulate!
-                *pack_voltage += cell_voltage >> 8;
+            reg_voltages[0] = cell_1;
+            *pack_voltage += cell_1 >> 8;
 
-                // Check under/over voltage
-                if (cell_voltage >= OVERVOLTAGE_THRESHOLD) {
+            if (cell_1 >= OVERVOLTAGE_THRESHOLD) {
+                *ov += 1;
+            } else if (cell_1 <= UNDERVOLTAGE_THRESHOLD) {
+                *uv += 1;
+            }
+
+            // Skip REG_B and REG_D cells 2 and 3 since we don't use them on the
+            // chip
+            if (!((cell_reg == 1) || (cell_reg == 3))) {
+                reg_voltages[1] = cell_2;
+                *pack_voltage += cell_2 >> 8;
+
+                if (cell_2 >= OVERVOLTAGE_THRESHOLD) {
                     *ov += 1;
-                } else if (cell_voltage <= UNDERVOLTAGE_THRESHOLD) {
+                } else if (cell_2 <= UNDERVOLTAGE_THRESHOLD) {
                     *uv += 1;
                 }
 
-                data_counter += 2;
+                reg_voltages[2] = cell_3;
+                *pack_voltage += cell_3 >> 8;
+
+                if (cell_3 >= OVERVOLTAGE_THRESHOLD) {
+                    *ov += 1;
+                } else if (cell_3 <= UNDERVOLTAGE_THRESHOLD) {
+                    *uv += 1;
+                }
             }
+
+            uint16_t received_pec
+                = (raw_data[raw_idx + 6] << 8) + raw_data[raw_idx + 7];
 
             can_send(&voltage_frame);
 
@@ -90,16 +117,12 @@ int voltage_task(uint16_t* pack_voltage, uint32_t* ov, uint32_t* uv) {
              * is transmitted as the 7th and 8th
              * after the 6 cell voltage data bytes
              */
-            uint16_t received_pec
-                = (raw_data[data_counter] << 8) | raw_data[data_counter + 1];
-
             uint16_t data_pec
                 = pec15_calc(NUM_BYTES_IN_REG, &raw_data[(ic)*NUM_RX_BYT]);
 
             if (received_pec != data_pec) {
                 pec_errors++;
             }
-            data_counter = data_counter + 2;
         } // end foreach ltc6811
     } // end foreach cell reg (A, B, C, D)
 

--- a/vehicle/mkv/software/bms/tasks/voltage_task.c
+++ b/vehicle/mkv/software/bms/tasks/voltage_task.c
@@ -70,7 +70,9 @@ int voltage_task(uint16_t* pack_voltage, uint32_t* ov, uint32_t* uv) {
              * report the average instead
              */
             if ((cell_reg == 2) && (ic == 5)) {
-                uint32_t average = (cell_1 + cell_2 + cell_3) / 3;
+                uint16_t average
+                    = ((cell_1 >> 8) + (cell_2 >> 8) + (cell_3 >> 8)) / 3;
+                average <<= 8;
                 cell_1 = (uint16_t)average;
                 cell_2 = (uint16_t)average;
                 cell_3 = (uint16_t)average;

--- a/vehicle/mkv/software/bms/tasks/voltage_task.c
+++ b/vehicle/mkv/software/bms/tasks/voltage_task.c
@@ -12,8 +12,6 @@
 #define CELL_GROUP_1_OFFSET (0) // Cells 1-4
 #define CELL_GROUP_2_OFFSET (4) // Cells 7-10
 
-// uint16_t cell_voltages[NUM_ICS][NUM_CELLS_PER_IC];
-
 int voltage_task(uint16_t* pack_voltage, uint32_t* ov, uint32_t* uv) {
     *pack_voltage = 0;
     int pec_errors = 0;
@@ -107,34 +105,3 @@ int voltage_task(uint16_t* pack_voltage, uint32_t* ov, uint32_t* uv) {
 
     return pec_errors;
 }
-
-// void can_send_bms_voltages(void) {
-//     can_frame_t voltage_frame = {
-//         //
-//         // .id = CAN_TOOLS_BMS_VOLTAGE_0_FRAME_ID,
-//         .mob = 0,
-//         .dlc = 8,
-//     };
-//
-//     for (uint8_t ic = 0; ic < NUM_ICS; ic++) {
-//         // For every chip, send the lower and upper cell voltages in CAN
-//         frames
-//
-//         /*
-//          * Trick: instead of creating our own data array, we just set the
-//          * pointer to the array to be the pointer to the cell voltages in
-//          giant
-//          * array with some offset. That way, we can reuse memory and avoid
-//          * memcpy-ing.
-//          */
-//         voltage_frame.data
-//             = (uint8_t*)(cell_voltages[ic] + CELL_GROUP_1_OFFSET);
-//         can_send(&voltage_frame);
-//         voltage_frame.id++;
-//
-//         voltage_frame.data
-//             = (uint8_t*)(cell_voltages[ic] + CELL_GROUP_2_OFFSET);
-//         can_send(&voltage_frame);
-//         voltage_frame.id++;
-//     }
-// }


### PR DESCRIPTION
Previously, we got all BMS temperatures at the same time. This took a very long time because we had to wait for SPI _and_ I2C. Now, the `temperature_task` function doesn't loop through the muxes and channels.

Instead, each time the function is called, it increments the channel it is using and performs the measurement for all the LTC6811s. Then, the next time it is called, it switches to the next channel. So each time the function `temperature_task` is called, we only measure one temperature, but it increments each time.

This should fix timing issues in the BMS that was causing the state machine to take 500+ ms (!!!) to run.

This also calibrates under and overtemperature thresholds for the BMS (-20C to 60C).