### PR TITLE
Fix CI issue with black formatting failing

### DIFF
--- a/.github/python-black.sh
+++ b/.github/python-black.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+GITHUB_SHA=${GITHUB_SHA:=$(git rev-parse HEAD)}
+GITHUB_BASE_REF=${GITHUB_BASE_REF:=main}
+
+CHANGED_PY_FILES=$(git diff --name-only origin/$GITHUB_BASE_REF..$(git rev-parse --short "$GITHUB_SHA") | grep ".py$")
+
+if [[ ! -z ${CHANGED_PY_FILES} ]]; then
+    echo "Changed .py files:"
+    echo ${CHANGED_PY_FILES}
+    black --check --diff ${CHANGED_PY_FILES}
+else
+    echo "No Python files changed"
+fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,4 +37,4 @@ jobs:
       run: pip install black
 
     - name: Run black on changed python files
-      run: git diff --name-only origin/$GITHUB_BASE_REF..$(git rev-parse --short "$GITHUB_SHA") | grep ".py$" | xargs black --check --diff
+      run: ./.github/python-black.sh

--- a/projects/can_api/utils.py
+++ b/projects/can_api/utils.py
@@ -8,8 +8,6 @@ def get_rx_messages(subs, messages):
 
     mobs = {}
 
-    print("HI")
-
     for m in subs:
         mobs[m["name"]] = m["mob"]
 

--- a/projects/can_api/utils.py
+++ b/projects/can_api/utils.py
@@ -8,6 +8,8 @@ def get_rx_messages(subs, messages):
 
     mobs = {}
 
+    print("HI")
+
     for m in subs:
         mobs[m["name"]] = m["mob"]
 


### PR DESCRIPTION
At some point, CI broke so that when we have PRs that have no Python files changed, CI:Lint fails because `black` (Python formatter) fails due to no input files. This should remedy that error so we only check Python file formatting when Python files have been edited.