### PR TITLE
Add enum generation to CAN API

### DIFF
--- a/projects/can_api/c_generator.py
+++ b/projects/can_api/c_generator.py
@@ -1,6 +1,7 @@
 import yaml
 from cantools.database.can import Database as CANDatabase
 import argparse
+
 # from yaml_handler import YamlParser
 from utils import get_rx_messages
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -48,10 +49,12 @@ def main():
 
         for sig in message["signals"]:
             if sig["unit"]["type"] == "enum":
-                choices.append({
-                    "name": sig["name"],
-                    "values": sig["unit"]["values"],
-                })
+                choices.append(
+                    {
+                        "name": sig["name"],
+                        "values": sig["unit"]["values"],
+                    }
+                )
 
     if "subscribe" in yaml_data.keys():
         rx_messages, mobs, masks = get_rx_messages(yaml_data["subscribe"], db.messages)
@@ -60,10 +63,12 @@ def main():
             for sig in msg.signals:
                 if sig.choices:
                     if len(sig.choices) > 2:
-                        choices.append({
-                            "name": sig.name,
-                            "values": list(sig.choices.values()),
-                        })
+                        choices.append(
+                            {
+                                "name": sig.name,
+                                "values": list(sig.choices.values()),
+                            }
+                        )
     else:
         rx_messages = []
         mobs = {}

--- a/projects/can_api/c_generator.py
+++ b/projects/can_api/c_generator.py
@@ -46,15 +46,16 @@ def main():
     for message in yaml_data["publish"]:
         msg = db.get_message_by_name(message["name"])
         tx_messages.append(msg)
-
-        for sig in message["signals"]:
-            if sig["unit"]["type"] == "enum":
-                choices.append(
-                    {
-                        "name": sig["name"],
-                        "values": sig["unit"]["values"],
-                    }
-                )
+        
+        if "signals" in message.keys():
+            for sig in message["signals"]:
+                if sig["unit"]["type"] == "enum":
+                    choices.append(
+                        {
+                            "name": sig["name"],
+                            "values": sig["unit"]["values"],
+                        }
+                    )
 
     if "subscribe" in yaml_data.keys():
         rx_messages, mobs, masks = get_rx_messages(yaml_data["subscribe"], db.messages)

--- a/projects/can_api/c_generator.py
+++ b/projects/can_api/c_generator.py
@@ -46,7 +46,7 @@ def main():
     for message in yaml_data["publish"]:
         msg = db.get_message_by_name(message["name"])
         tx_messages.append(msg)
-        
+
         if "signals" in message.keys():
             for sig in message["signals"]:
                 if sig["unit"]["type"] == "enum":

--- a/projects/can_api/c_generator.py
+++ b/projects/can_api/c_generator.py
@@ -1,7 +1,7 @@
 import yaml
 from cantools.database.can import Database as CANDatabase
 import argparse
-from yaml_handler import YamlParser
+# from yaml_handler import YamlParser
 from utils import get_rx_messages
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 import os
@@ -41,11 +41,29 @@ def main():
 
     # Filter messages to get only the ones our Node sends
     tx_messages = []
+    choices = []
     for message in yaml_data["publish"]:
-        tx_messages.append(db.get_message_by_name(message["name"]))
+        msg = db.get_message_by_name(message["name"])
+        tx_messages.append(msg)
+
+        for sig in message["signals"]:
+            if sig["unit"]["type"] == "enum":
+                choices.append({
+                    "name": sig["name"],
+                    "values": sig["unit"]["values"],
+                })
 
     if "subscribe" in yaml_data.keys():
         rx_messages, mobs, masks = get_rx_messages(yaml_data["subscribe"], db.messages)
+
+        for msg in rx_messages:
+            for sig in msg.signals:
+                if sig.choices:
+                    if len(sig.choices) > 2:
+                        choices.append({
+                            "name": sig.name,
+                            "values": list(sig.choices.values()),
+                        })
     else:
         rx_messages = []
         mobs = {}
@@ -79,7 +97,10 @@ def main():
 
     with open(h_out, "w+") as f:
         contents = h_template.render(
-            node=node, tx_messages=tx_messages, rx_messages=rx_messages
+            node=node,
+            tx_messages=tx_messages,
+            rx_messages=rx_messages,
+            choices=choices,
         )
 
         f.write(contents)

--- a/projects/can_api/dbc_generator.py
+++ b/projects/can_api/dbc_generator.py
@@ -5,32 +5,31 @@ from yaml_handler import YamlParser
 
 __version__ = "2021.12.28"
 
+
 def main():
     """
     CLI to generate a DBC file from YAML files
     """
     parser = argparse.ArgumentParser(
-        description = "Generate DBC from YAML and DBC files",
+        description="Generate DBC from YAML and DBC files",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     parser.add_argument(
-        '-o', '--output',
-        default='out.dbc',
-        help='Output filename (default is out.dbc)'
+        "-o", "--output", default="out.dbc", help="Output filename (default is out.dbc)"
     )
 
     parser.add_argument(
-        'inputs',
-        help='Input YAML and DBC files',
+        "inputs",
+        help="Input YAML and DBC files",
         nargs="+",
     )
 
     args = parser.parse_args()
 
     db = CANDatabase(
-        strict = True,
-        version = __version__,
+        strict=True,
+        version=__version__,
     )
 
     # Add in extra DBC files
@@ -45,5 +44,6 @@ def main():
 
     dump_file(db, args.output)
 
+
 if __name__ == "__main__":
-  main()
+    main()

--- a/projects/can_api/files/c_templates/h_file.j2
+++ b/projects/can_api/files/c_templates/h_file.j2
@@ -1,7 +1,17 @@
+#pragma once
 #include <stdint.h>
 
 #include "libs/can/api.h"
 #include "can_tools.h"
+
+/*
+ * Enums
+ */
+{% for enum in choices %}
+enum {{ enum["name"] }}_e { {% for choice in enum["values"] %}
+    {{ enum["name"]|upper }}_{{ choice|upper }},{% endfor %}
+};
+{% endfor %}
 
 /*
  * Initialize the {{ node.name }} CAN peripheral

--- a/vehicle/mkv/software/air_control/air.c
+++ b/vehicle/mkv/software/air_control/air.c
@@ -407,7 +407,7 @@ int main(void) {
             run_1ms = false;
         }
 
-        if (air_control_critical.air_state == IDLE) {
+        if (air_control_critical.air_state == AIR_STATE_IDLE) {
             updater_loop();
         }
 

--- a/vehicle/mkv/software/air_control/air.c
+++ b/vehicle/mkv/software/air_control/air.c
@@ -233,7 +233,7 @@ static void state_machine_run(void) {
 
                 if (motor_controller_voltage
                     > (PRECHARGE_THRESHOLD * pack_voltage)) {
-                    gpio_set_pin(AIR_N_LSD); // Close AIR_N
+                    gpio_set_pin(AIR_N_LSD); // Close AIR negative
                     gpio_clear_pin(PRECHARGE_CTL); // Close precharge relay
                     once = true;
                     air_control_critical.air_state = AIR_STATE_TS_ACTIVE;
@@ -261,7 +261,7 @@ static void state_machine_run(void) {
 
             /*
              * This pattern ensures that we only call get_time() once because we
-             * only want to capture the time that PRECHARGE starts
+             * only want to capture the time that DISCHARGE starts
              */
             static bool once = true;
 

--- a/vehicle/mkv/software/air_control/air.c
+++ b/vehicle/mkv/software/air_control/air.c
@@ -22,34 +22,7 @@ image_hdr_t image_hdr __attribute__((section(".image_hdr"))) = {
     .git_sha = STABLE_GIT_COMMIT,
 };
 
-enum State {
-    INIT = 0,
-    IDLE,
-    SHUTDOWN_CIRCUIT_CLOSED,
-    PRECHARGE,
-    TS_ACTIVE,
-    DISCHARGE,
-    FAULT,
-};
-
-enum FaultCode {
-    AIR_FAULT_NONE = 0x00,
-    AIR_FAULT_AIR_N_WELD,
-    AIR_FAULT_AIR_P_WELD,
-    AIR_FAULT_BOTH_AIRS_WELD,
-    AIR_FAULT_PRECHARGE_FAIL,
-    AIR_FAULT_DISCHARGE_FAIL,
-    AIR_FAULT_PRECHARGE_FAIL_RELAY_WELDED, // TODO?
-    AIR_FAULT_CAN_ERROR,
-    AIR_FAULT_CAN_BMS_TIMEOUT,
-    AIR_FAULT_CAN_MC_TIMEOUT,
-    AIR_FAULT_SHUTDOWN_IMPLAUSIBILITY,
-    AIR_FAULT_MOTOR_CONTROLLER_VOLTAGE,
-    AIR_FAULT_BMS_VOLTAGE,
-    AIR_FAULT_IMD_STATUS,
-};
-
-static void set_fault(enum FaultCode the_fault) {
+static void set_fault(enum air_fault_e the_fault) {
     gpio_set_pin(FAULT_LED);
 
     if (air_control_critical.air_fault == AIR_FAULT_NONE) {
@@ -184,17 +157,17 @@ bail:
 
 static void state_machine_run(void) {
     if (air_control_critical.air_fault != AIR_FAULT_NONE) {
-        air_control_critical.air_state = FAULT;
+        air_control_critical.air_state = AIR_STATE_FAULT;
     }
 
     switch (air_control_critical.air_state) {
-        case IDLE: {
+        case AIR_STATE_IDLE: {
             // Idle until shutdown circuit is closed
             if (air_control_critical.ss_tsms) {
-                air_control_critical.air_state = SHUTDOWN_CIRCUIT_CLOSED;
+                air_control_critical.air_state = AIR_STATE_SHUTDOWN_CIRCUIT_CLOSED;
             }
         } break;
-        case SHUTDOWN_CIRCUIT_CLOSED: {
+        case AIR_STATE_SHUTDOWN_CIRCUIT_CLOSED: {
             /*
              * This pattern ensures that we only call get_time() once because we
              * only want to capture the time that PRECHARGE starts
@@ -208,7 +181,7 @@ static void state_machine_run(void) {
 
             if (get_time() - start_time < 200) {
                 if (air_control_critical.air_p_status) {
-                    air_control_critical.air_state = PRECHARGE;
+                    air_control_critical.air_state = AIR_STATE_PRECHARGE;
                     once = true;
                 }
             } else {
@@ -217,7 +190,7 @@ static void state_machine_run(void) {
             }
             return;
         } break;
-        case PRECHARGE: {
+        case AIR_STATE_PRECHARGE: {
             // Start precharge
             gpio_set_pin(PRECHARGE_CTL);
 
@@ -262,7 +235,7 @@ static void state_machine_run(void) {
                     gpio_set_pin(AIR_N_LSD); // Close AIR_N
                     gpio_clear_pin(PRECHARGE_CTL); // Close precharge relay
                     once = true;
-                    air_control_critical.air_state = TS_ACTIVE;
+                    air_control_critical.air_state = AIR_STATE_TS_ACTIVE;
                     return;
                 } else {
                     once = true;
@@ -274,15 +247,15 @@ static void state_machine_run(void) {
                 return;
             }
         } break;
-        case TS_ACTIVE: {
+        case AIR_STATE_TS_ACTIVE: {
             // If any of the shutdown nodes open, the SS_TSMS will trigger as
             // well, so we can just read that one (it is the last node in the
             // shutdown circuit.
             if (!air_control_critical.ss_tsms) {
-                air_control_critical.air_state = DISCHARGE;
+                air_control_critical.air_state = AIR_STATE_DISCHARGE;
             }
         } break;
-        case DISCHARGE: {
+        case AIR_STATE_DISCHARGE: {
             gpio_clear_pin(AIR_N_LSD);
 
             /*
@@ -299,17 +272,17 @@ static void state_machine_run(void) {
             if (get_time() - start_time > 100) {
                 if (air_control_critical.air_p_status
                     && air_control_critical.air_n_status) {
-                    air_control_critical.air_state = FAULT;
+                    air_control_critical.air_state = AIR_STATE_FAULT;
                     set_fault(AIR_FAULT_BOTH_AIRS_WELD);
                     once = true;
                     return;
                 } else if (air_control_critical.air_p_status) {
-                    air_control_critical.air_state = FAULT;
+                    air_control_critical.air_state = AIR_STATE_FAULT;
                     set_fault(AIR_FAULT_AIR_P_WELD);
                     once = true;
                     return;
                 } else if (air_control_critical.air_n_status) {
-                    air_control_critical.air_state = FAULT;
+                    air_control_critical.air_state = AIR_STATE_FAULT;
                     set_fault(AIR_FAULT_AIR_N_WELD);
                     once = true;
                     return;
@@ -341,7 +314,7 @@ static void state_machine_run(void) {
 
             if (motor_controller_voltage < MOTOR_CONTROLLER_THRESHOLD_LOW_dV) {
                 once = true;
-                air_control_critical.air_state = IDLE;
+                air_control_critical.air_state = AIR_STATE_IDLE;
                 return;
             } else {
                 set_fault(AIR_FAULT_DISCHARGE_FAIL);
@@ -349,14 +322,14 @@ static void state_machine_run(void) {
                 return;
             }
         } break;
-        case FAULT: {
+        case AIR_STATE_FAULT: {
             gpio_set_pin(FAULT_LED);
             gpio_clear_pin(PRECHARGE_CTL);
             gpio_clear_pin(AIR_N_LSD);
         } break;
         default: {
             // Shouldn't happen, but just in case
-            air_control_critical.air_state = FAULT;
+            air_control_critical.air_state = AIR_STATE_FAULT;
         } break;
     }
 }
@@ -399,7 +372,7 @@ int main(void) {
     gpio_clear_pin(SS_HVD);
 
     updater_init(BTLDR_ID, 5);
-    air_control_critical.air_state = INIT;
+    air_control_critical.air_state = AIR_STATE_INIT;
 
     // Initialize interrupts
     sei();
@@ -424,7 +397,7 @@ int main(void) {
     // Send message again after initial checks are run
     can_send_air_control_critical();
 
-    air_control_critical.air_state = IDLE;
+    air_control_critical.air_state = AIR_STATE_IDLE;
 
     while (1) {
         // Run state machine every 1ms

--- a/vehicle/mkv/software/air_control/air.c
+++ b/vehicle/mkv/software/air_control/air.c
@@ -164,7 +164,8 @@ static void state_machine_run(void) {
         case AIR_STATE_IDLE: {
             // Idle until shutdown circuit is closed
             if (air_control_critical.ss_tsms) {
-                air_control_critical.air_state = AIR_STATE_SHUTDOWN_CIRCUIT_CLOSED;
+                air_control_critical.air_state
+                    = AIR_STATE_SHUTDOWN_CIRCUIT_CLOSED;
             }
         } break;
         case AIR_STATE_SHUTDOWN_CIRCUIT_CLOSED: {

--- a/vehicle/mkv/software/air_control/air.yml
+++ b/vehicle/mkv/software/air_control/air.yml
@@ -21,20 +21,20 @@ publish:
         unit:
           type: enum
           values:
-            - FAULT_NONE
-            - FAULT_AIR_N_WELD
-            - FAULT_AIR_P_WELD
-            - FAULT_BOTH_AIRS_WELD
-            - FAULT_PRECHARGE_FAIL
-            - FAULT_DISCHARGE_FAIL
-            - FAULT_PRECHARGE_FAIL_RELAY_WELDED
-            - FAULT_CAN_ERROR
-            - FAULT_CAN_BMS_TIMEOUT
-            - FAULT_CAN_MC_TIMEOUT
-            - FAULT_SHUTDOWN_IMPLAUSIBILITY
-            - FAULT_MOTOR_CONTROLLER_VOLTAGE
-            - FAULT_BMS_VOLTAGE
-            - FAULT_IMD_STATUS
+            - NONE
+            - AIR_N_WELD
+            - AIR_P_WELD
+            - BOTH_AIRS_WELD
+            - PRECHARGE_FAIL
+            - DISCHARGE_FAIL
+            - PRECHARGE_FAIL_RELAY_WELDED
+            - CAN_ERROR
+            - CAN_BMS_TIMEOUT
+            - CAN_MC_TIMEOUT
+            - SHUTDOWN_IMPLAUSIBILITY
+            - MOTOR_CONTROLLER_VOLTAGE
+            - BMS_VOLTAGE
+            - IMD_STATUS
       - name: air_state
         slice: 8 + 8
         unit:

--- a/vehicle/mkv/software/bms/bms.yml
+++ b/vehicle/mkv/software/bms/bms.yml
@@ -9,20 +9,20 @@ publish:
     id: 0x10
     freq_hz: 100
     signals:
-      - name: bms_fault_state
+      - name: bms_fault
         slice: 0 + 4
         unit:
           type: enum
           values:
-            - BMS_FAULT_NONE
-            - BMS_FAULT_UNDERVOLTAGE
-            - BMS_FAULT_OVERVOLTAGE
-            - BMS_FAULT_UNDERTEMPERATURE
-            - BMS_FAULT_OVERTEMPERATURE
-            - BMS_FAULT_DIAGNOSTICS_FAIL
-            - BMS_FAULT_OPEN_WIRE
-            - BMS_FAULT_OVERCURRENT
-            - BMS_FAULT_PEC
+            - NONE
+            - UNDERVOLTAGE
+            - OVERVOLTAGE
+            - UNDERTEMPERATURE
+            - OVERTEMPERATURE
+            - DIAGNOSTICS_FAIL
+            - OPEN_WIRE
+            - OVERCURRENT
+            - PEC
       - name: bms_state
         slice: 4 + 4
         unit:

--- a/vehicle/mkv/software/bms/utils/fault.c
+++ b/vehicle/mkv/software/bms/utils/fault.c
@@ -5,10 +5,10 @@
 
 #include "libs/gpio/api.h"
 
-void set_fault(enum FaultCode the_fault) {
+void set_fault(enum bms_fault_e the_fault) {
     gpio_clear_pin(BMS_RELAY_LSD);
 
-    if (bms_core.bms_fault_state == BMS_FAULT_NONE) {
-        bms_core.bms_fault_state = the_fault;
+    if (bms_core.bms_fault == BMS_FAULT_NONE) {
+        bms_core.bms_fault = the_fault;
     }
 }

--- a/vehicle/mkv/software/bms/utils/fault.h
+++ b/vehicle/mkv/software/bms/utils/fault.h
@@ -1,51 +1,52 @@
 #pragma once
+#include "vehicle/mkv/software/bms/can_api.h"
 
-enum FaultCode {
-    /*
-     * Normal operation
-     */
-    BMS_FAULT_NONE = 0x00,
+// enum FaultCode {
+//     /*
+//      * Normal operation
+//      */
+//     BMS_FAULT_NONE = 0x00,
+//
+//     /*
+//      * Battery needs to be charged. Can be cleared by connecting the charger.
+//      */
+//     BMS_FAULT_UNDERVOLTAGE,
+//
+//     /*
+//      * Over-voltage, occurs when batteries are charged above 4.2 volts. This
+//      * shouldn't happen, but exists and can occur.
+//      */
+//     BMS_FAULT_OVERVOLTAGE,
+//
+//     /*
+//      * Cell temperatures are too low
+//      */
+//     BMS_FAULT_UNDERTEMPERATURE,
+//
+//     /*
+//      * Cell temperatures are too high
+//      */
+//     BMS_FAULT_OVERTEMPERATURE,
+//
+//     /*
+//      * LTC6811 self-test fails
+//      */
+//     BMS_FAULT_DIAGNOSTICS_FAIL,
+//
+//     /*
+//      * Open-wire exists between LTC6811 and cells
+//      */
+//     BMS_FAULT_OPEN_WIRE,
+//
+//     /*
+//      * Too much current into/out of cells
+//      */
+//     BMS_FAULT_OVERCURRENT,
+//
+//     /*
+//      * Received too many packet encoding errors from LTC6811s
+//      */
+//     BMS_FAULT_PEC,
+// };
 
-    /*
-     * Battery needs to be charged. Can be cleared by connecting the charger.
-     */
-    BMS_FAULT_UNDERVOLTAGE,
-
-    /*
-     * Over-voltage, occurs when batteries are charged above 4.2 volts. This
-     * shouldn't happen, but exists and can occur.
-     */
-    BMS_FAULT_OVERVOLTAGE,
-
-    /*
-     * Cell temperatures are too low
-     */
-    BMS_FAULT_UNDERTEMPERATURE,
-
-    /*
-     * Cell temperatures are too high
-     */
-    BMS_FAULT_OVERTEMPERATURE,
-
-    /*
-     * LTC6811 self-test fails
-     */
-    BMS_FAULT_DIAGNOSTICS_FAIL,
-
-    /*
-     * Open-wire exists between LTC6811 and cells
-     */
-    BMS_FAULT_OPEN_WIRE,
-
-    /*
-     * Too much current into/out of cells
-     */
-    BMS_FAULT_OVERCURRENT,
-
-    /*
-     * Received too many packet encoding errors from LTC6811s
-     */
-    BMS_FAULT_PEC,
-};
-
-void set_fault(enum FaultCode the_fault);
+void set_fault(enum bms_fault_e the_fault);

--- a/vehicle/mkv/software/dashboard/dashboard.c
+++ b/vehicle/mkv/software/dashboard/dashboard.c
@@ -113,9 +113,9 @@ int main(void) {
         // BMS Core message for BMS Status LED
         if (can_poll_receive_bms_core() == 0) {
             if (bms_core.bms_fault != BMS_FAULT_NONE) { // check BMS status
-                gpio_set_pin(BMS_LED); // set BMS light high
+                gpio_set_pin(BMS_LED); // BMS ON means ERROR
             } else {
-                gpio_clear_pin(BMS_LED); // BMS OFF means NOT OK
+                gpio_clear_pin(BMS_LED); // BMS OFF means OK
             }
 
             // Receive again

--- a/vehicle/mkv/software/dashboard/dashboard.c
+++ b/vehicle/mkv/software/dashboard/dashboard.c
@@ -112,7 +112,7 @@ int main(void) {
 
         // BMS Core message for BMS Status LED
         if (can_poll_receive_bms_core() == 0) {
-            if (bms_core.bms_fault_state
+            if (bms_core.bms_fault
                 != BMS_FAULT_NONE) { // check BMS status
                 gpio_set_pin(BMS_LED); // set BMS light high
             } else {

--- a/vehicle/mkv/software/dashboard/dashboard.c
+++ b/vehicle/mkv/software/dashboard/dashboard.c
@@ -112,8 +112,7 @@ int main(void) {
 
         // BMS Core message for BMS Status LED
         if (can_poll_receive_bms_core() == 0) {
-            if (bms_core.bms_fault
-                != BMS_FAULT_NONE) { // check BMS status
+            if (bms_core.bms_fault != BMS_FAULT_NONE) { // check BMS status
                 gpio_set_pin(BMS_LED); // set BMS light high
             } else {
                 gpio_clear_pin(BMS_LED); // BMS OFF means NOT OK


### PR DESCRIPTION
Wrote this code a while ago but forgot about it. Not sure if it still has merit, but figured I'd post for posterity's sake.

---

This PR adds generation of C enums to the CAN API. Previously, we had duplicated information: we defined enums in both the YAML file of the CAN API *and* in the C source code, meaning that if one was updated, the other had to be updated as well. Now, we will be able to just use the YAML as a single source of truth and the generated code has enums that the C source can use. I will post an example here in a few days, but in the meantime I updated all the firmware images to implement this new feature.