### PR TITLE
feat: empty parts libraries for onboarding

### DIFF
--- a/parts/schematic/oem.kicad_sym
+++ b/parts/schematic/oem.kicad_sym
@@ -1,0 +1,2 @@
+(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
+)


### PR DESCRIPTION
In order for members to add the new parts library to KiCad in needs to exist on their computers - this will put in an empty folder so they can set up KiCad properly even though we haven't added components to this library yet.