### PR TITLE
EEPROM configuration for sensing board location

### DIFF
--- a/vehicle/mkvi/software/sensing/BUILD
+++ b/vehicle/mkvi/software/sensing/BUILD
@@ -1,29 +1,13 @@
 load("//bazel/tools:defs.bzl", "can_api_files")
-load("//bazel:defs.bzl", "cc_firmware")
+# load("//bazel:defs.bzl", "cc_firmware")
+load (":build.bzl", "sensing_firmware")
 
 exports_files([
     "sensing.yml",
 ])
 
-cc_firmware(
-    name = "sensing",
-    srcs = [
-        "sensing.c",
-        "sensing.h",
-    ],
-    btldr = "//projects/btldr:brakelight_bspd_btldr",
-    target_compatible_with = [
-        "//bazel/constraints:atmega16m1",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":can_api",
-        "//libs/adc",
-        "//libs/gpio",
-        "//libs/timer",
-        "//projects/btldr:btldr_lib",
-    ],
-)
+sensing_firmware("front")
+sensing_firmware("rear")
 
 can_api_files(
     name = "can_api",

--- a/vehicle/mkvi/software/sensing/build.bzl
+++ b/vehicle/mkvi/software/sensing/build.bzl
@@ -1,0 +1,30 @@
+load("//bazel:defs.bzl", "cc_firmware")
+
+def sensing_firmware(location):
+    defines = {}
+
+    if location == "front":
+        defines["SENSING_LOCATION"] = 0
+
+    if location == "rear":
+        defines["SENSING_LOCATION"] = 1
+
+    cc_firmware(
+        name = "sensing_{}".format(location),
+        srcs = [
+            "sensing.c",
+            "sensing.h",
+        ],
+        defines = defines,
+        target_compatible_with = [
+            "//bazel/constraints:atmega16m1",
+        ],
+        visibility = ["//visibility:public"],
+        deps = [
+            ":can_api",
+            "//libs/adc",
+            "//libs/gpio",
+            "//libs/timer",
+            "//projects/btldr:btldr_lib",
+        ],
+    )


### PR DESCRIPTION
This PR adds an EEPROM configuration that tells the sensing controller which location it is in (front vs rear) so that it knows which CAN messages to send out.