### PR TITLE
Fix issues with hardware filtering

### DIFF
--- a/projects/btldr/py_client/btldr.py
+++ b/projects/btldr/py_client/btldr.py
@@ -327,9 +327,20 @@ class BtldrManager:
             ]
         )
 
-        maybe_response = self.canbus.recv(timeout)
+        while True:
+            maybe_response = self.canbus.recv(timeout)
+
+            if maybe_response == None:
+                break
+
+            if maybe_response.arbitration_id != ecu_id + offset:
+                continue
+            else:
+                break
+
 
         if maybe_response:
-            return self.db.decode_message(offset, maybe_response.data)
+            r = self.db.decode_message(offset, maybe_response.data)
+            return r
         else:
             return None

--- a/projects/btldr/py_client/btldr.py
+++ b/projects/btldr/py_client/btldr.py
@@ -338,7 +338,6 @@ class BtldrManager:
             else:
                 break
 
-
         if maybe_response:
             r = self.db.decode_message(offset, maybe_response.data)
             return r


### PR DESCRIPTION
There is an issue with the python-can library where calling `set_filters` on the bus doesn't seem to work. Not sure why this is, so I've implemented a quick fix solution for it.