### PR TITLE
Fix to allow building with avr-gcc 12+

### DIFF
--- a/bazel/toolchain/avr.bzl
+++ b/bazel/toolchain/avr.bzl
@@ -82,6 +82,7 @@ def _impl(ctx):
             ft.all_warnings_as_errors,
             ft.dbg,
             ft.opt,
+            ft.set_min_page_size,
             ft.device,
         ],
     )

--- a/bazel/toolchain/features.bzl
+++ b/bazel/toolchain/features.bzl
@@ -72,6 +72,19 @@ _OPT_FEATURE = feature(
     provides = ["compilation_mode"],
 )
 
+_SET_MIN_PAGE_SIZE = feature(
+    name = "set_min_page_size",
+    enabled = False,
+    flag_sets = [
+        flag_set(
+            actions = _C_ALL_COMPILE_ACTIONS,
+            flag_groups = [
+                flag_group(flags = ["--param=min-pagesize=0"]),
+            ],
+        ),
+    ],
+)
+
 _DEFAULT_FEATURE = feature(
     name = "default",
     enabled = True,
@@ -111,6 +124,7 @@ CC_ALL_COMMON_FEATURES_INFO = {
     "opt": "Compile a release build with, optimisation turned on",
     "default": "Default C flags",
     "device": "The device name and CPU frequency",
+    "set_min_page_size": "Set minimum page size to 0 to prevent warning",
     "type_name": "The type name for this provider",
 }
 
@@ -123,6 +137,7 @@ def AvrGetCommonFeatures(device_name, device_frequency):
         dbg = _DEBUG_FEATURE,
         opt = _OPT_FEATURE,
         default = _DEFAULT_FEATURE,
+        set_min_page_size = _SET_MIN_PAGE_SIZE,
         device = AvrDeviceFeature(device_name, device_frequency),
         type_name = "cc_all_common_feature_info",
     )


### PR DESCRIPTION
While I was working on the BMS firmware, I realized that I couldn't build any firmware images due to some previously unseen compiler warnings in our 16m1 libraries. This was odd to me, as we hadn't touched those libraries in a long time. After doing some digging, I found this bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523.

Essentially, starting with avr-gcc 12, they added some warning checks/made some stricter, but this had the unintended effect of throwing warnings for some AVR builds, and since we treat all warnings as errors, we were unable to compile. There's a flag we can add to our compile process to mitigate this, but unfortunately the flag was only added to avr-gcc 12, so if we just add it to all builds, it would fail for anyone who's running an older version.

This PR adds that flag (`--param=min-pagesize=0`) as a _bazel feature_, which allows us to enable it on demand from the `bazel build` command like so for anyone running avr-gcc 12+
```bash
bazel build --config=16m1 -c opt --features=set_min_page_size //vehicle/mkvi/software/bms
```