### PR TITLE
Firmware Session 1 Homework

### DIFF
--- a/tutorials/power_distribution/BUILD
+++ b/tutorials/power_distribution/BUILD
@@ -1,0 +1,15 @@
+# bazel build --config=16m1 -c opt //tutorials/power_distribution
+load("//bazel:defs.bzl", "cc_firmware")
+
+cc_firmware(
+    name = "power_distribution",
+    srcs = [
+        "main.c",
+        "power_distribution.c",
+        "api.h",
+    ],
+    target_compatible_with = ["//bazel/constraints:avr"],
+    deps = [
+        "//libs/gpio",
+    ],
+)

--- a/tutorials/power_distribution/BUILD
+++ b/tutorials/power_distribution/BUILD
@@ -4,9 +4,9 @@ load("//bazel:defs.bzl", "cc_firmware")
 cc_firmware(
     name = "power_distribution",
     srcs = [
+        "api.h",
         "main.c",
         "power_distribution.c",
-        "api.h",
     ],
     target_compatible_with = ["//bazel/constraints:avr"],
     deps = [

--- a/tutorials/power_distribution/api.h
+++ b/tutorials/power_distribution/api.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "libs/gpio/api.h"
+#include "libs/gpio/pin_defs.h"
+
+extern gpio_t DASHBOARD_POWER;
+extern gpio_t SERVICE_SECTION_POWER;
+extern gpio_t THROTTLE_POWER;
+
+void init_devices();
+void power_device();
+void power_all();
+void power_off_device();
+void power_off_all();

--- a/tutorials/power_distribution/api.h
+++ b/tutorials/power_distribution/api.h
@@ -1,14 +1,32 @@
 #pragma once
 
 #include "libs/gpio/api.h"
-#include "libs/gpio/pin_defs.h"
 
 extern gpio_t DASHBOARD_POWER;
 extern gpio_t SERVICE_SECTION_POWER;
 extern gpio_t THROTTLE_POWER;
 
-void init_devices();
-void power_device();
-void power_all();
-void power_off_device();
-void power_off_all();
+/*
+ * Initialize power distribution device pins
+ */
+void init_devices(void);
+
+/*
+ * Power a device
+ */
+void power_device(gpio_t device);
+
+/*
+ * Power all devices
+ */
+void power_all(void);
+
+/*
+ * Power off a device
+ */
+void power_off_device(gpio_t device);
+
+/*
+ * Power off all devices
+ */
+void power_off_all(void);

--- a/tutorials/power_distribution/main.c
+++ b/tutorials/power_distribution/main.c
@@ -1,0 +1,25 @@
+// Power distribution library testing
+#include <util/delay.h>
+
+#include "tutorials/power_distribution/api.h"
+
+#define BLINK_PERIOD_ms (400)
+
+int main(void) {
+    init_devices();
+
+    for (;;) {
+        power_all();
+        _delay_ms(BLINK_PERIOD_ms);
+        power_off_all();
+        _delay_ms(BLINK_PERIOD_ms);
+        power_device(DASHBOARD_POWER);
+        _delay_ms(BLINK_PERIOD_ms);
+        power_device(SERVICE_SECTION_POWER);
+        _delay_ms(BLINK_PERIOD_ms);
+        power_device(THROTTLE_POWER);
+        _delay_ms(BLINK_PERIOD_ms);
+        power_off_all();
+        _delay_ms(BLINK_PERIOD_ms);
+    }
+}

--- a/tutorials/power_distribution/power_distribution.c
+++ b/tutorials/power_distribution/power_distribution.c
@@ -1,0 +1,33 @@
+#include "libs/gpio/api.h"
+#include "libs/gpio/pin_defs.h"
+#include "tutorials/power_distribution/api.h"
+
+gpio_t DASHBOARD_POWER = PB5;
+gpio_t SERVICE_SECTION_POWER = PB6;
+gpio_t THROTTLE_POWER = PB7;
+
+void init_devices() {
+    gpio_set_mode(DASHBOARD_POWER, OUTPUT);
+    gpio_set_mode(SERVICE_SECTION_POWER, OUTPUT);
+    gpio_set_mode(THROTTLE_POWER, OUTPUT);
+}
+
+void power_device(gpio_t device) {
+    gpio_set_pin(device);
+}
+
+void power_all() {
+    gpio_set_pin(DASHBOARD_POWER);
+    gpio_set_pin(SERVICE_SECTION_POWER);
+    gpio_set_pin(THROTTLE_POWER);
+}
+
+void power_off_device(gpio_t device) {
+    gpio_clear_pin(device);
+}
+
+void power_off_all() {
+    gpio_clear_pin(DASHBOARD_POWER);
+    gpio_clear_pin(SERVICE_SECTION_POWER);
+    gpio_clear_pin(THROTTLE_POWER);
+}

--- a/tutorials/power_distribution/power_distribution.c
+++ b/tutorials/power_distribution/power_distribution.c
@@ -6,7 +6,7 @@ gpio_t DASHBOARD_POWER = PB5;
 gpio_t SERVICE_SECTION_POWER = PB6;
 gpio_t THROTTLE_POWER = PB7;
 
-void init_devices() {
+void init_devices(void) {
     gpio_set_mode(DASHBOARD_POWER, OUTPUT);
     gpio_set_mode(SERVICE_SECTION_POWER, OUTPUT);
     gpio_set_mode(THROTTLE_POWER, OUTPUT);
@@ -16,7 +16,7 @@ void power_device(gpio_t device) {
     gpio_set_pin(device);
 }
 
-void power_all() {
+void power_all(void) {
     gpio_set_pin(DASHBOARD_POWER);
     gpio_set_pin(SERVICE_SECTION_POWER);
     gpio_set_pin(THROTTLE_POWER);
@@ -26,7 +26,7 @@ void power_off_device(gpio_t device) {
     gpio_clear_pin(device);
 }
 
-void power_off_all() {
+void power_off_all(void) {
     gpio_clear_pin(DASHBOARD_POWER);
     gpio_clear_pin(SERVICE_SECTION_POWER);
     gpio_clear_pin(THROTTLE_POWER);


### PR DESCRIPTION
Added a `main.c` to test the power_distribution library. Tested and working with a board with 3 LEDs.

Questions:
- Is there a better way to expose the devices outside of the power distribution library than using `extern` in `api.h`?
- Is there a better place to put `gpio_set_mode` for each device instead of an explicit `init_devices` function?
- Is there a better way to power all devices and power off all devices other than making repeated calls to set and clear the pins?