### PR TITLE
Update CAN Dashboard for MKVI

### DIFF
--- a/projects/canviewer/BUILD
+++ b/projects/canviewer/BUILD
@@ -10,6 +10,7 @@ py_binary(
     data = [
         ":config.yml",
         "//vehicle/mkv:mkv.dbc",
+        "//vehicle/mkvi:mkvi.dbc",
     ],
     main = "canviewer.py",
     visibility = ["//visibility:public"],

--- a/projects/canviewer/README.md
+++ b/projects/canviewer/README.md
@@ -9,12 +9,15 @@ It also is fully configurable via YAML.
 ## Using the tool
 1. Set up your CAN device if you are using a PCAN or other socketcan device. Instruction for this can be found [here](https://docs.olinelectricmotorsports.com/doc/how-to-use-can-HYcXsHAf2g)
     - You can also use this tool with a virtual CAN bus
-2. Run the tool! This is done using the command `bazel run //projects/canviewer`. There are two command line arguments as well
+2. Run the tool! This is done using the command `bazel run //projects/canviewer`. There are three command line arguments as well
     - `-b` - Either `seeedstudio` or `socketcan` 
     - `-c` - Channel
         - Socketcan: this is the network interface name you created when setting up your device (usually can0 for real hardware or vcan0 for a virtual CAN bus)
         - Seeedstudio: this is the _device path_ for your CAN dongle. Typically this will be something like `/dev/ttyUSB0`. The best way to find it is to run `ls /dev/ttyUSB*`, which lists all the USB device paths, before and after you plug in your dongle to find the one that was added. The number starts at 0 and increments every time something is plugged in, so if you unplug and replug your CAN dongle, the number will change!
-    - These arguments would be passed like so for a bustype of seeedstudio and a USB device at /dev/tty/USB0: 
+    - `-d` - the DBC file to be used to decode the CAN messages. This is specified as a file path starting from the root of the monorepo.
+        - This has a default value of `vehicle/mkvi/mkvi.dbc` - in other words, if you want to decode messages from MKVI or a MKVI board, you do not need to specify this argument. If you're reading this in future years, feel free to update the default value in a new PR - just be sure to add your DBC as a dependency in the BUILD file for this project.
+        - You can check `//vehicle/mkvi/BUILD` to see which DBC/YAML files are included in the master DBC
+    - These arguments would be passed like so for a bustype of seeedstudio and a USB device at /dev/tty/USB0 when plugged into MKVI:
         ```
         bazel run //projects/canviewer -- -b seeedstudio -c /dev/tty/USB0
         ```

--- a/projects/canviewer/README.md
+++ b/projects/canviewer/README.md
@@ -7,7 +7,7 @@ The dashboard uses a QT GUI and includes support for SocketCan (for example, the
 It also is fully configurable via YAML.
 
 ## Using the tool
-1. Set up your CAN device if you are using a PCAN or other socketcan device. Instruction for this can be found [here](https://docs.olinelectricmotorsports.com/doc/how-to-use-can-HYcXsHAf2g)
+1. Set up your CAN device if you are using a PCAN or other socketcan device. Instruction for this can be found [here](https://coda.io/d/_dbuFnC2EA_e/How-to-use-CAN_suzvC)
     - You can also use this tool with a virtual CAN bus
 2. Run the tool! This is done using the command `bazel run //projects/canviewer`. There are three command line arguments as well
     - `-b` - Either `seeedstudio` or `socketcan` 

--- a/projects/canviewer/canviewer.py
+++ b/projects/canviewer/canviewer.py
@@ -13,8 +13,6 @@ import cantools
 
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import QTimer
-from rich.layout import Layout
-from rich.live import Live
 
 REFRESH_RATE = 100  # GUI refresh rate in ms
 
@@ -81,11 +79,17 @@ if __name__ == "__main__":
         default="vcan0",
         help="Either a network interface name for socketcan, or the path of the USB device for seeedstudio",
     )
+    parser.add_argument(
+        "-d",
+        "--dbc",
+        default="vehicle/mkvi/mkvi.dbc",
+        help="Path to the DBC file to use for decoding CAN messages; default is the MKVI DBC",
+    )
 
     args = parser.parse_args()
 
     can_bus, db, kill_flag = init_can(
-        args.canbus, args.bustype, 500000, rx_callback, "vehicle/mkv/mkv.dbc"
+        args.canbus, args.bustype, 500000, rx_callback, args.dbc
     )
 
     def update_ui():

--- a/projects/canviewer/config.yml
+++ b/projects/canviewer/config.yml
@@ -12,15 +12,19 @@ ss_imd:
 ss_tsms:
 ---
 # Vehicle Values
+throttle_l_pos:
+throttle_r_pos:
+brake_gate:
+ready_to_drive:
 air_p_status:
 air_n_status:
-ready_to_drive:
 pack_voltage:
 max_temperature:
   processing_function: convertVtoT
 min_temperature:
   processing_function: convertVtoT
 D1_DC_Bus_Voltage:
+Torque_Command:
 ---
 # Vehicle States (state and fault)
 air_control_critical:


### PR DESCRIPTION
small changes
- make the DBC argument specifiable via command line, and change the default to mkvi.dbc from mkv.dbc
- add better default values to config.yml (things like throttle_pos, brake_gate, and Torque_Command were missing even though you usually want those visible)
- remove unused imports (rich) - holdover from its days as a TUI