### PR TITLE
Add Clang and Buildifier Formatting to Pre-Commit Hooks

### DIFF
--- a/scripts/buildifier-format.sh
+++ b/scripts/buildifier-format.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Ensure go and buildifier are installed
+if ! command -v go &>/dev/null; then
+    echo "go could not be found. Install with 'sudo apt install golang'"
+    exit 1
+
+elif ! command -v buildifier &>/dev/null; then
+    echo "buildifier could not be found. Install with \
+'go install github.com/bazelbuild/buildtools/buildfier@latest',"
+    echo "then add 'export PATH=$PATH:$HOME/go/bin' your .bashrc"
+    exit 1
+fi
+
+if [ -z "$1" ]; then
+    echo "No command specified. Use one of: \"check-branch\", \
+\"reformat-branch\", \"check-staged\", or \"reformat-staged\""
+    exit 1
+fi
+
+# check bazel files in the current branch
+if [ "$1" = "check-branch" ]; then
+    commit_id=$(git show-ref "${GITHUB_BASE_REF:-origin/main}" | awk '{print $1}')
+    changed_files=$(git diff --name-only "$commit_id" | grep -iE '(BUILD|WORKSPACE|.bzl)$')
+    out=""
+    for file in $changed_files; do
+        file_out=$(buildifier -mode=check "$file" 2>&1)
+        out="$out""$file_out"
+    done
+    if [ -z "$out" ]; then
+        echo "No Bazel files to reformat on the current branch"
+    else
+        echo "$out"
+    fi
+    exit 0
+
+# format bazel files in the current branch
+elif [ "$1" = "reformat-branch" ]; then
+    commit_id=$(git show-ref "${GITHUB_BASE_REF:-origin/main}" | awk '{print $1}')
+    changed_files=$(git diff --name-only "$commit_id" | grep -iE '(BUILD|WORKSPACE|.bzl)$')
+    for file in $changed_files; do
+        buildifier -mode=fix "$file"
+    done
+    exit 0
+
+# check staged bazel files
+elif [ "$1" = "check-staged" ]; then
+    out=""
+    for file in $(git diff --staged --name-only | grep -iE '(BUILD|WORKSPACE|.bzl)$'); do
+        file_out=$(buildifier -mode=check "$file" 2>&1)
+        out="$out$file_out"
+    done
+    if [ -z "$out" ]; then
+        echo "No staged Bazel files to reformat"
+    else
+        echo "$out"
+    fi
+    exit 0
+
+# format staged bazel files; bazel file formatting for pre-commit
+elif [ "$1" = "reformat-staged" ]; then
+    for file in $(git diff --staged --name-only | grep -iE '(BUILD|WORKSPACE|.bzl)$'); do
+        buildifier -mode=fix "$file"
+        git add "$file"
+    done
+    exit 0
+
+else
+    echo "Command not recognized. Use one of: \"check-branch\", \
+\"reformat-branch\", \"check-staged\", or \"reformat-staged\""
+    exit 1
+fi

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -17,7 +17,7 @@ if [ "$1" = "check-branch" ]; then
     out=$(git-clang-format -f --diff --commit $commit_id --style=file -q)
 
     if [ "$out" != "no modified files to format" ] && [ "$out" != "" ]; then
-        echo "Formatting errors, run ./scripts/clang_format.sh reformat"
+        echo "Formatting errors, run ./scripts/clang_format.sh reformat-branch"
         exit 1
     fi
     exit 0
@@ -26,6 +26,15 @@ if [ "$1" = "check-branch" ]; then
 elif [ "$1" = "reformat-branch" ]; then
     git-clang-format -f --style=file --commit origin/main
     exit 0
+
+# check staged c files
+elif [ "$1" = "check-staged" ]; then
+    out=$(git-clang-format -f --diff --staged --style=file -q)
+
+    if [ "$out" != "no modified files to format" ] && [ "$out" != "" ]; then
+        echo "Formatting errors, run ./scripts/clang_format.sh reformat-staged"
+        exit 1
+    fi
 
 # format staged c files; clang formatting for pre-commit
 elif [ "$1" = "reformat-staged" ]; then

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -7,7 +7,8 @@ if ! command -v git-clang-format &>/dev/null; then
 fi
 
 if [ -z "$1" ]; then
-    echo "No command specified. Use either \"reformat\" or \"check\""
+    echo "No command specified. Use one of: \"check-branch\", \
+\"reformat-branch\", \"check-staged\", or \"reformat-staged\""
     exit 1
 fi
 
@@ -45,6 +46,7 @@ elif [ "$1" = "reformat-staged" ]; then
     exit 0
 
 else
-    echo "Command not recognized. Use either \"reformat\" or \"check\""
+    echo "Command not recognized. Use one of: \"check-branch\", \
+\"reformat-branch\", \"check-staged\", or \"reformat-staged\""
     exit 1
 fi

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -26,6 +26,7 @@ elif [ "$1" = "reformat" ]; then
     exit 0
 
 elif [ "$1" = "commit-reformat" ]; then
+    # clang formatting for pre-commit; only format staged c files
     for file in $(git diff --staged --name-only | grep -iE '\.(c|h|cpp|hpp)$'); do
         clang-format --style=file -i "$file"
         git add "$file"

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -11,7 +11,8 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-if [ "$1" = "check" ]; then
+# check c files in the current branch
+if [ "$1" = "check-branch" ]; then
     commit_id=$(git show-ref ${GITHUB_BASE_REF:-origin/main} | awk '{print $1}')
     out=$(git-clang-format -f --diff --commit $commit_id --style=file -q)
 
@@ -21,12 +22,13 @@ if [ "$1" = "check" ]; then
     fi
     exit 0
 
-elif [ "$1" = "reformat" ]; then
+# format c files in the current branch
+elif [ "$1" = "reformat-branch" ]; then
     git-clang-format -f --style=file --commit origin/main
     exit 0
 
-elif [ "$1" = "commit-reformat" ]; then
-    # clang formatting for pre-commit; only format staged c files
+# format staged c files; clang formatting for pre-commit
+elif [ "$1" = "reformat-staged" ]; then
     for file in $(git diff --staged --name-only | grep -iE '\.(c|h|cpp|hpp)$'); do
         clang-format --style=file -i "$file"
         git add "$file"

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,33 +1,37 @@
 #!/bin/bash
 
 # Ensure git-clang-format is installed
-if ! command -v git-clang-format &> /dev/null
-then
+if ! command -v git-clang-format &>/dev/null; then
     echo "git-clang-format could not be found. Install with sudo apt install clang-format"
     exit 1
 fi
 
-if [ -z "$1" ]
-then
+if [ -z "$1" ]; then
     echo "No command specified. Use either \"reformat\" or \"check\""
     exit 1
 fi
 
-if [ "$1" = "check" ]
-then
+if [ "$1" = "check" ]; then
     commit_id=$(git show-ref ${GITHUB_BASE_REF:-origin/main} | awk '{print $1}')
     out=$(git-clang-format -f --diff --commit $commit_id --style=file -q)
 
-    if [ "$out" != "no modified files to format" ] && [ "$out" != "" ]
-    then
+    if [ "$out" != "no modified files to format" ] && [ "$out" != "" ]; then
         echo "Formatting errors, run ./scripts/clang_format.sh reformat"
         exit 1
     fi
-
     exit 0
-elif [ "$1" = "reformat" ]
-then
+
+elif [ "$1" = "reformat" ]; then
     git-clang-format -f --style=file --commit origin/main
+    exit 0
+
+elif [ "$1" = "commit-reformat" ]; then
+    for file in $(git diff --staged --name-only | grep -iE '\.(c|h|cpp|hpp)$'); do
+        clang-format --style=file -i "$file"
+        git add "$file"
+    done
+    exit 0
+
 else
     echo "Command not recognized. Use either \"reformat\" or \"check\""
     exit 1

--- a/scripts/install_kicad_git_hooks.sh
+++ b/scripts/install_kicad_git_hooks.sh
@@ -74,7 +74,10 @@ fi
 git add ${ROOT}/parts/schematic/oem
 
 # format with clang
-${ROOT}/scripts/clang-format.sh commit-reformat
+${ROOT}/scripts/clang-format.sh reformat-commit
+
+# format with buildifier
+${ROOT}/scripts/buildifier-format.sh reformat-staged
 EOF
 
 # make hooks executable
@@ -84,3 +87,4 @@ chmod +x ${ROOT}/.git/hooks/pre-commit
 
 # make hook dependencies executable
 chmod +x ${ROOT}/scripts/clang-format.sh
+chmod +x ${ROOT}/scripts/buildifier-format.sh

--- a/scripts/install_kicad_git_hooks.sh
+++ b/scripts/install_kicad_git_hooks.sh
@@ -6,7 +6,7 @@ ROOT=$(git rev-parse --show-toplevel)
 
 # install virtual pre-checkout hook
 # the pre-checkout hook will prevent checkout if the symbols haven't been commited
-cat << EOF > ${ROOT}/.git/hooks/pre-checkout
+cat <<EOF >${ROOT}/.git/hooks/pre-checkout
 #!/bin/bash
 # parameters:
 # 1: previous HEAD
@@ -43,7 +43,7 @@ EOF
 
 # install post-checkout hook
 # the post-checkout hook generates a kicad_sym file from the symbols in parts/schematic/oem
-cat << EOF > ${ROOT}/.git/hooks/post-checkout
+cat <<EOF >${ROOT}/.git/hooks/post-checkout
 #!/bin/bash
 # parameters:
 # 1: previous HEAD
@@ -65,13 +65,16 @@ EOF
 # install pre-commit hook
 # the pre-commit hook generates files for parts/schematic/oem from a kicad_sym file
 
-cat << EOF > ${ROOT}/.git/hooks/pre-commit
+cat <<EOF >${ROOT}/.git/hooks/pre-commit
 #!/bin/bash
 if test -f ${ROOT}/parts/schematic/oem.kicad_sym; then
     rm -rf ${ROOT}/parts/schematic/oem
     bazel run //tools/symbols:convert -- library2symbols --source ${ROOT}/parts/schematic/oem.kicad_sym --out ${ROOT}/parts/schematic/oem
 fi
 git add ${ROOT}/parts/schematic/oem
+
+# format with clang
+${ROOT}/scripts/clang-format.sh commit-reformat
 EOF
 
 # make hooks executable
@@ -79,3 +82,5 @@ chmod +x ${ROOT}/.git/hooks/pre-checkout
 chmod +x ${ROOT}/.git/hooks/post-checkout
 chmod +x ${ROOT}/.git/hooks/pre-commit
 
+# make hook dependencies executable
+chmod +x ${ROOT}/scripts/clang-format.sh

--- a/scripts/install_kicad_git_hooks.sh
+++ b/scripts/install_kicad_git_hooks.sh
@@ -74,7 +74,7 @@ fi
 git add ${ROOT}/parts/schematic/oem
 
 # format with clang
-${ROOT}/scripts/clang-format.sh reformat-commit
+${ROOT}/scripts/clang-format.sh reformat-staged
 
 # format with buildifier
 ${ROOT}/scripts/buildifier-format.sh reformat-staged


### PR DESCRIPTION
Adds Clang and Builder formatting for C and Bazel files to pre-commit hooks.

Changes:

`install_kicad_git_hooks.sh`

- add Clang formatting to pre-commit
- add Buildifier formatting to pre-commit
- make Clang and Buildifier scripts executable

These could be added to separate hooks for firmware development, though Bazel file formatting is still helpful for any PR.

`clang-format.sh`

- rename `check` to `check-branch`
- rename `reformat` to `reformat-branch`
- add `check-staged`
- add `reformat-staged` for pre-commit

Core script works the same as before, just with clearer flags. Two additional flags were added for checking staged files and formatting staged files.

`buildifier-format.sh`

- add `check-branch`
- add `reformat-branch`
- add `check-staged`
- add `reformat-staged` for pre-commit

Similar functionality to `clang-format.sh` but for Bazel files.

Looking for feedback on these - they work for me based on some initial testing. Also open to splitting formatting from Kicad hooks or seeking an alternative route (e.g. Github actions) for reformatting.