### PR TITLE
Add Kicad lck Files to Gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ _autosave-*
 *-save.kicad_pcb
 fp-info-cache
 *-backups/
+*.lck
 
 # Netlist files
 *.net


### PR DESCRIPTION
Kicad lock files were introduced in a recent version - this pr adds `.lck` files to `.gitignore`.